### PR TITLE
feat: add modal UI for Add Exam with validation and difficulty selector

### DIFF
--- a/css/style_index.css
+++ b/css/style_index.css
@@ -216,3 +216,144 @@
       width: 25px;
     }
 }
+
+/* modal overlay */
+.modal-overlay {
+    position: fixed;
+    inset: 0;             
+    background: rgba(0, 0, 0, 0.5); 
+    opacity: 0;                    
+    pointer-events: none;         
+    z-index: 999;                    
+    transition: opacity 0.2s ease;   
+}
+.modal-overlay.active {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+/* exam form */
+.add-exam-form {
+    position: fixed;               
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(0.95); 
+    background-color: #fff;
+    width: 90%;
+    max-width: 500px;
+    height: auto;               
+    max-height: 90vh;            
+    z-index: 1000;                  
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+    display: flex;
+    flex-direction: column;
+    padding: 24px;
+    gap: 0.5rem;                  
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+
+    h2{
+        font-family: "Story Script", cursive;
+        font-size: 200%;
+        margin-bottom: 1rem;
+    }
+}
+.add-exam-form.active {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translate(-50%, -50%) scale(1);
+}
+.add-exam-form label {
+    font-weight: 600;
+    margin-bottom: 10px;
+    display: block;
+}
+.add-exam-form input[type="text"],
+.add-exam-form input[type="date"],
+.add-exam-form input[type="number"] {
+    width: 85%;
+    padding: 10px 12px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    font-size: 16px;
+    outline: none;
+    transition: border-color 0.2s;
+    margin-bottom: 1rem;
+}
+.add-exam-form input:focus {
+    border: 2px solid #5C3E94;
+}
+.form-buttons {
+    display: flex;
+    gap: 10px;      
+    justify-content: flex-start; 
+    margin-top: 1rem;
+}
+.form-buttons button {
+    display: flex;      
+    align-items: center;
+    gap: 8px;
+    padding: 0.8rem;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 16px;
+    transition: background-color 0.2s;
+}
+.form-buttons button img {
+    width: 15px;
+    height: auto;
+}
+.add-exam-form button[type="submit"] {
+    background-color: #5C3E94;
+    color: white;
+}
+.add-exam-form button[type="submit"]:hover {
+    background-color: #7755C9;
+}
+.add-exam-form button[type="button"] {
+    background-color: #ccc;
+}
+.add-exam-form button[type="button"]:hover {
+    background-color: #aaa;
+}
+.input-group {
+    position: relative;
+    margin-bottom: 16px;
+}
+.input-status {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    color: white;
+    text-align: center;
+    line-height: 20px;
+    font-weight: bold;
+    font-size: 14px;
+    background-color: red;
+}
+.input-status.valid {
+    background-color: green;
+    content: "✔";
+}
+/*difficulty selector*/
+.difficulty-selector {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 1rem;
+}
+.dot {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background-color: lightgray;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}

--- a/html/index.html
+++ b/html/index.html
@@ -88,10 +88,55 @@
                     <h1>Upcoming Exams</h1>
                     <p id="number-of-exams">0</p>
                 </div>
-                <button class="add-exam"> <img src="../images/plus.png" alt="plus icon"> Add Exam</button>
+                <button class="add-exam" id="add-exam-button" onclick="openExamModal()"> <img src="../images/plus.png" alt="plus icon"> Add Exam</button>
             </div>
         </div>
 
+        <!-- Modal Overlay -->
+        <div id="modal-overlay" class="modal-overlay"></div>
+
+        <!-- Add exam section -->
+         <div id="add-exam-form" class="add-exam-form">
+            <h2>Add New Exam</h2>
+            <form id="exam-form">
+                <div class="input-group">
+                    <label for="exam-name">Exam Name:</label>
+                    <input type="text" id="exam-name" name="exam-name" required>
+                    <span class="input-status">!</span>
+                </div>
+
+                <div class="input-group">
+                    <label for="exam-date">Exam Date:</label>
+                    <input type="date" id="exam-date" name="exam-date" required>
+                    <span class="input-status">!</span>
+                </div>
+
+                <div class="input-group">
+                    <label for="exam-subject">Subject:</label>
+                    <input type="text" id="exam-subject" name="exam-subject" required>
+                    <span class="input-status">!</span>
+                </div>
+
+                <div class="input-group">
+                    <label for="exam-difficulty">Exam Difficulty:</label>
+                    <div id="exam-difficulty" class="difficulty-selector">
+                        <span class="dot" data-value="1"></span>
+                        <span class="dot" data-value="2"></span>
+                        <span class="dot" data-value="3"></span>
+                        <span class="dot" data-value="4"></span>
+                        <span class="dot" data-value="5"></span>
+                    </div>
+                    <input type="hidden" id="exam-difficulty-value" name="exam-difficulty" value="1">
+                    <span class="input-status">!</span>
+                </div>
+                <div class="form-buttons">
+                    <button type="submit"><img src="../images/plus.png" alt="plus icon"> Add Exam</button>
+                    <button type="button" onclick="closeExamModal()">Cancel</button>
+                </div>
+            </form>
+        </div>
+
+        <!-- Footer -->
         <footer class="footer">
             <div class="footer-content">
                 <img src="../images/open-book.png" alt="StudyFlow Logo">

--- a/script/calendar.js
+++ b/script/calendar.js
@@ -81,5 +81,6 @@ document.getElementById("next-week").onclick = () => {
 renderWeek();
 
 //test events
-db.exams.add({ name: "Math Exam", date: formatDate(new Date()) });
-db.exams.add({ name: "Project Reminder", date: formatDate(new Date(new Date().setDate(new Date().getDate() + 2))) });
+
+//db.exams.add({ name: "Math Exam", date: formatDate(new Date()) });
+//db.exams.add({ name: "Project Reminder", date: formatDate(new Date(new Date().setDate(new Date().getDate() + 2))) });

--- a/script/index.js
+++ b/script/index.js
@@ -25,3 +25,97 @@ function updateGreeting() {
     }
 }
 updateGreeting();   
+
+// Exam modal functionality and form
+const modal = document.getElementById("add-exam-form");
+const overlay = document.getElementById("modal-overlay");
+
+function openExamModal() {
+    modal.classList.add("active");
+    overlay.classList.add("active");
+}
+
+function closeExamModal() {
+    modal.classList.remove("active");
+    overlay.classList.remove("active");
+
+    const form = document.getElementById("exam-form");
+    form.reset(); 
+
+    const value = 0;
+    hiddenInput.value = value;
+    colorDots(value); 
+
+    const inputStatuses = form.querySelectorAll(".input-status");
+    inputStatuses.forEach(status => {
+        status.textContent = "!";
+        status.style.backgroundColor = "red";
+    });
+}
+
+// Close modal when clicking outside
+overlay.addEventListener("click", closeExamModal);
+
+//exam difficulty selection
+const dots = document.querySelectorAll(".difficulty-selector .dot");
+const hiddenInput = document.getElementById("exam-difficulty-value");
+const defaultColor = "lightgray";
+const colors = ["#4CAF50", "#8BC34A", "#FFEB3B", "#FF9800", "#F44336"];
+
+function colorDots(value) {
+    const color = colors[value - 1]; 
+    dots.forEach((dot, i) => {
+        dot.style.backgroundColor = i < value ? color : defaultColor;
+    });
+}
+
+dots.forEach(dot => {
+    const value = parseInt(dot.dataset.value);
+
+    dot.addEventListener("click", () => {
+        colorDots(value);
+        hiddenInput.value = value;
+    });
+
+    dot.addEventListener("mouseover", () => {
+        colorDots(value);
+    });
+
+    dot.addEventListener("mouseout", () => {
+        const savedValue = parseInt(hiddenInput.value);
+        colorDots(savedValue);
+    });
+});
+
+// real-time input validation
+const form = document.getElementById("exam-form");
+const inputs = form.querySelectorAll("input:not([type=hidden])");
+
+inputs.forEach(input => {
+    const statusIcon = input.nextElementSibling; 
+
+    input.addEventListener("input", () => {
+        if (input.value.trim() === "") {
+            statusIcon.textContent = "!";
+            statusIcon.style.backgroundColor = "red";
+        } else {
+            statusIcon.textContent = "✔";
+            statusIcon.style.backgroundColor = "green";
+        }
+    });
+});
+
+const difficultyInput = document.getElementById("exam-difficulty-value");
+const difficultyStatus = document.querySelector("#exam-difficulty").parentElement.querySelector(".input-status");
+
+document.querySelectorAll("#exam-difficulty .dot").forEach(dot => {
+    dot.addEventListener("click", () => {
+        if (parseInt(difficultyInput.value) > 0) {
+            difficultyStatus.textContent = "✔";
+            difficultyStatus.style.backgroundColor = "green";
+        } else {
+            difficultyStatus.textContent = "!";
+            difficultyStatus.style.backgroundColor = "red";
+        }
+    });
+});


### PR DESCRIPTION
This PR introduces the **Add Exam modal UI** for StudyFlow, setting up the structure and visual elements needed to add exams. Functionality for saving or processing the exam is not included yet.

Changes include:

- Modal layout for adding an exam (name, date, subject, difficulty)
- Difficulty selector with 5 clickable dots, prepared for future coloring logic
- Visual validation indicators (!) for empty fields next to inputs
- Buttons styled inline with icons for "Add Exam" and "Cancel"
- Modal overlay and proper centering with flexbox
- Form reset when closing the modal, clearing inputs and visual indicators

This PR is primarily **UI and structure**, laying the groundwork for implementing exam storage and logic in future updates.