### PR TITLE
calendar scheduler overhaul, smart study planning & visual upgrades

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -8,26 +8,132 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
   <style>
-    /* ── Check button ─────────────────────────────────────── */
+
+    /* ══════════════════════════════════════════════════════════
+       CALENDAR ENHANCEMENTS
+    ══════════════════════════════════════════════════════════ */
+
+    /* ── Week progress bar ─────────────────────────────────── */
+    .week-progress-bar {
+      width: 100%; height: 5px;
+      background: var(--border);
+      border-radius: 999px;
+      margin: .6rem 0 1.1rem;
+      overflow: hidden;
+    }
+    .week-progress-fill {
+      height: 100%;
+      background: linear-gradient(90deg, var(--primary), hsl(260,80%,70%));
+      border-radius: 999px;
+      transition: width .6s cubic-bezier(.4,0,.2,1);
+    }
+    .week-progress-label {
+      display: flex; justify-content: space-between;
+      font-size: .7rem; font-weight: 600;
+      color: var(--muted-foreground);
+      margin-bottom: .25rem;
+    }
+    .week-progress-label span:last-child { color: var(--primary); font-family: 'DM Mono', monospace; }
+
+    /* ── Jump to today button ──────────────────────────────── */
+    .jump-today-btn {
+      display: inline-flex; align-items: center; gap: .35rem;
+      padding: .35rem .85rem; border-radius: 999px;
+      font-size: .76rem; font-weight: 700; font-family: inherit;
+      cursor: pointer; border: 1.5px solid var(--border);
+      background: white; color: var(--foreground);
+      transition: all .18s; white-space: nowrap;
+    }
+    .jump-today-btn:hover { border-color: var(--primary); color: var(--primary); background: rgba(132,34,209,.06); }
+
+    /* ── Week nav row ──────────────────────────────────────── */
+    .week-nav-row {
+      display: flex; align-items: center; gap: .75rem;
+      margin-bottom: 0;
+    }
+    .week-nav-row .week-range { flex: 1; text-align: center; }
+
+    /* ── Day cell: completion ring ─────────────────────────── */
+    .day-cell { position: relative; overflow: visible; }
+    .day-ring-wrap {
+      position: absolute; top: .3rem; right: .3rem;
+      width: 22px; height: 22px;
+    }
+    .day-ring-wrap svg { width: 22px; height: 22px; transform: rotate(-90deg); }
+    .day-ring-bg  { fill: none; stroke: rgba(0,0,0,.07); stroke-width: 2.5; }
+    .day-ring-fill{ fill: none; stroke-width: 2.5; stroke-linecap: round;
+                    transition: stroke-dashoffset .5s cubic-bezier(.4,0,.2,1); }
+    .day-cell.exam-day-cell .day-ring-bg  { stroke: rgba(255,255,255,.15); }
+
+    /* ── Exam day cell ─────────────────────────────────────── */
+    .day-cell.exam-day-cell {
+      background: #111 !important;
+      border-color: #111 !important;
+      color: #fff !important;
+    }
+    .day-cell.exam-day-cell .day-name,
+    .day-cell.exam-day-cell .day-number { color: #fff !important; }
+    .day-cell.exam-day-cell .indicator-bar { background: rgba(255,255,255,.35) !important; }
+    .exam-day-pill {
+      font-size: .55rem; font-weight: 800; letter-spacing: .07em;
+      text-transform: uppercase;
+      background: rgba(255,255,255,.18); color: #fff;
+      border-radius: 999px; padding: .1rem .45rem;
+      margin-top: .25rem; display: inline-block;
+    }
+
+    /* ── Day progress text ─────────────────────────────────── */
+    .day-prog-text {
+      font-size: .6rem; font-weight: 700; color: var(--success);
+      margin-top: .1rem; font-family: 'DM Mono', monospace;
+    }
+
+    /* ── Indicator colours ─────────────────────────────────── */
+    .indicator-bar.project         { background: hsl(221,83%,53%); }
+    .indicator-bar.reminder        { background: hsl(38,80%,40%); }
+    .indicator-bar.reminder-notify { background: hsl(38,80%,60%); }
+    .indicator-bar.exam-day        { background: #111; }
+
+    /* ── Session cards: colored left border ────────────────── */
+    .session-item { border-left: 3px solid transparent; border-radius: .65rem !important; transition: border-color .15s, box-shadow .15s; }
+    .session-item.completed      { border-left-color: var(--success); }
+    .session-item.scheduled-item { border-left-color: var(--border); }
+    .session-item.scheduled-item:hover { border-left-color: var(--primary); box-shadow: 0 2px 12px rgba(132,34,209,.08); }
+    .session-item[data-color="success"]   { border-left-color: var(--success); }
+    .session-item[data-color="warning"]   { border-left-color: hsl(38,92%,50%); }
+    .session-item[data-color="danger"]    { border-left-color: var(--destructive); }
+    .session-item[data-color="very-danger"]{ border-left-color: hsl(280,70%,50%); }
+
+    /* ── Difficulty badge on session ───────────────────────── */
+    .diff-dot {
+      display: inline-block; width: 7px; height: 7px; border-radius: 50%;
+      margin-right: .3rem; flex-shrink: 0; vertical-align: middle;
+    }
+    .diff-dot.success    { background: var(--success); }
+    .diff-dot.warning    { background: hsl(38,92%,50%); }
+    .diff-dot.danger     { background: var(--destructive); }
+    .diff-dot.very-danger{ background: hsl(280,70%,50%); }
+
+    /* ── Check button ──────────────────────────────────────── */
     .cal-check-btn {
       display: inline-flex; align-items: center; gap: .35rem;
-      padding: .35rem .75rem; border-radius: 999px;
+      padding: .35rem .8rem; border-radius: 999px;
       font-size: .72rem; font-weight: 700; font-family: inherit;
       cursor: pointer; border: 1.5px solid var(--border);
       background: white; color: var(--muted-foreground);
-      transition: all .2s; white-space: nowrap; margin-top: .25rem;
+      transition: all .18s; white-space: nowrap; margin-top: .3rem;
     }
     .cal-check-btn:hover { border-color: var(--success); color: var(--success); background: rgba(22,163,74,.07); }
     .cal-check-btn.done  { border-color: var(--success); color: var(--success); background: rgba(22,163,74,.1); }
 
-    /* ── Score tag ────────────────────────────────────────── */
+    /* ── Score tag ─────────────────────────────────────────── */
     .cal-score-tag {
-      font-size: .68rem; font-weight: 600; color: var(--muted-foreground);
+      font-size: .67rem; font-weight: 600; color: var(--muted-foreground);
       margin-top: .2rem; display: flex; align-items: center; gap: .25rem;
     }
     .cal-score-tag.done { color: var(--success); }
 
-    /* ── Floating score toast ─────────────────────────────── */
+    /* ── Score toast ───────────────────────────────────────── */
     .cal-score-toast {
       position: fixed; bottom: 5rem; right: 1.5rem; z-index: 200;
       background: var(--foreground); color: #fff;
@@ -40,26 +146,190 @@
     }
     .cal-score-toast.visible { transform: translateY(0); opacity: 1; }
 
-    /* ── Day progress text ────────────────────────────────── */
-    .day-prog-text {
-      font-size: .62rem; font-weight: 700; color: var(--success);
-      margin-top: .15rem; font-family: 'DM Mono', monospace;
+    /* ── Exam day banner ───────────────────────────────────── */
+    .exam-day-block {
+      border: 2px solid #111; border-radius: .75rem;
+      background: #111; color: #fff;
+      padding: .75rem 1rem; margin-bottom: .5rem;
+      display: flex; align-items: center; gap: .75rem;
+      font-weight: 700; font-size: .9rem;
+    }
+    .exam-day-block .exam-day-icon { flex-shrink: 0; display: flex; align-items: center; }
+    .exam-day-block .exam-day-label {
+      font-size: .58rem; font-weight: 800; letter-spacing: .09em;
+      text-transform: uppercase; opacity: .6; margin-bottom: .15rem;
     }
 
-    /* ── Indicator colours for new types ─────────────────── */
-    .indicator-bar.project         { background: hsl(221,83%,53%); }
-    .indicator-bar.reminder        { background: hsl(38,80%,40%); }
-    .indicator-bar.reminder-notify { background: hsl(38,80%,60%); }
+    /* ── Session badges ────────────────────────────────────── */
+    .session-badge {
+      font-size: .67rem; font-weight: 700;
+      padding: .15rem .5rem; border-radius: 999px; margin-left: .35rem;
+    }
+    .session-badge.scheduled { background: rgba(132,34,209,.1); color: var(--primary); }
+    .session-badge.exam      { background: rgba(239,68,68,.12); color: var(--destructive); }
 
-    /* session badge colours for project/reminder */
-    .session-badge { font-size:.68rem; font-weight:700; padding:.15rem .5rem; border-radius:999px; margin-left:.35rem; }
-    .session-badge.scheduled { background:rgba(132,34,209,.1); color:var(--primary); }
-    .session-badge.exam      { background:rgba(239,68,68,.12); color:var(--destructive); }
-
-    /* session icon for project/reminder */
+    /* ── Session icons ─────────────────────────────────────── */
     .session-icon.project         { color: hsl(221,83%,53%); }
     .session-icon.reminder        { color: hsl(38,80%,40%); }
     .session-icon.reminder-notify { color: hsl(38,80%,60%); }
+
+    /* ══════════════════════════════════════════════════════════
+       EVENT CARDS — project / reminder / notify
+    ══════════════════════════════════════════════════════════ */
+    .event-card {
+      position: relative;
+      display: flex;
+      align-items: center;
+      gap: .85rem;
+      border-radius: .85rem;
+      padding: .85rem 1rem .85rem .9rem;
+      margin-bottom: .5rem;
+      overflow: hidden;
+      border: 1.5px solid transparent;
+      transition: transform .15s, box-shadow .15s;
+    }
+    .event-card:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 18px rgba(0,0,0,.08);
+    }
+
+    /* Left accent stripe */
+    .event-card__accent {
+      position: absolute;
+      left: 0; top: 0; bottom: 0;
+      width: 4px;
+      border-radius: 4px 0 0 4px;
+    }
+
+    /* Icon circle */
+    .event-card__icon {
+      flex-shrink: 0;
+      width: 38px; height: 38px;
+      border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+    }
+
+    /* Body */
+    .event-card__body { flex: 1; min-width: 0; }
+    .event-card__label {
+      font-size: .6rem; font-weight: 800;
+      letter-spacing: .08em; text-transform: uppercase;
+      margin-bottom: .18rem; opacity: .7;
+    }
+    .event-card__subject {
+      font-size: .88rem; font-weight: 700;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .event-card__topic {
+      font-size: .74rem; margin-top: .1rem; opacity: .65;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .event-card__notes {
+      font-size: .7rem; font-style: italic;
+      margin-top: .25rem; opacity: .6;
+    }
+
+    /* Right badge pill */
+    .event-card__badge {
+      flex-shrink: 0;
+      font-size: .6rem; font-weight: 800;
+      letter-spacing: .07em;
+      padding: .25rem .6rem;
+      border-radius: 999px;
+    }
+
+    /* ── Project variant — blue ────────────────────────────── */
+    .event-card--project {
+      background: hsl(221,100%,98%);
+      border-color: hsl(221,83%,88%);
+      color: hsl(221,50%,25%);
+    }
+    .event-card--project .event-card__accent { background: hsl(221,83%,53%); }
+    .event-card--project .event-card__icon   { background: hsl(221,83%,93%); color: hsl(221,83%,48%); }
+    .event-card--project .event-card__label  { color: hsl(221,83%,48%); }
+    .event-card--project .event-card__badge  {
+      background: hsl(221,83%,48%);
+      color: #fff;
+    }
+
+    /* ── Reminder variant — amber ──────────────────────────── */
+    .event-card--reminder {
+      background: hsl(38,100%,97%);
+      border-color: hsl(38,80%,80%);
+      color: hsl(38,60%,22%);
+    }
+    .event-card--reminder .event-card__accent { background: hsl(38,85%,48%); }
+    .event-card--reminder .event-card__icon   { background: hsl(38,90%,90%); color: hsl(38,85%,38%); }
+    .event-card--reminder .event-card__label  { color: hsl(38,85%,38%); }
+    .event-card--reminder .event-card__badge  {
+      background: hsl(38,85%,48%);
+      color: #fff;
+    }
+
+    /* ── Notify variant — soft purple ──────────────────────── */
+    .event-card--notify {
+      background: hsl(270,60%,98%);
+      border-color: hsl(270,50%,85%);
+      color: hsl(270,40%,28%);
+    }
+    .event-card--notify .event-card__accent { background: hsl(270,55%,62%); }
+    .event-card--notify .event-card__icon   { background: hsl(270,55%,92%); color: hsl(270,55%,52%); }
+    .event-card--notify .event-card__label  { color: hsl(270,55%,52%); }
+    .event-card--notify .event-card__badge  {
+      background: hsl(270,55%,62%);
+      color: #fff;
+    }
+
+    /* ── Week summary strip ────────────────────────────────── */
+    .week-summary-strip {
+      display: flex; gap: 1rem; flex-wrap: wrap;
+      padding: .85rem 1.1rem;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: .875rem;
+      margin-bottom: 1rem;
+      font-size: .78rem;
+    }
+    .wss-item { display: flex; align-items: center; gap: .45rem; color: var(--muted-foreground); }
+    .wss-item strong { color: var(--foreground); font-family: 'DM Mono', monospace; font-size: .85rem; }
+    .wss-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+
+    /* ── Mini month strip ──────────────────────────────────── */
+    .month-strip {
+      display: flex; gap: .3rem; overflow-x: auto; padding-bottom: .25rem;
+      margin-bottom: 1rem; scrollbar-width: none;
+    }
+    .month-strip::-webkit-scrollbar { display: none; }
+    .month-strip-day {
+      flex-shrink: 0; width: 32px; text-align: center;
+      border-radius: .5rem; padding: .25rem .1rem;
+      cursor: pointer; transition: background .15s;
+      font-size: .7rem; color: var(--muted-foreground);
+    }
+    .month-strip-day .ms-num {
+      font-weight: 700; font-size: .78rem; color: var(--foreground);
+      display: block; line-height: 1.4;
+    }
+    .month-strip-day .ms-dot { width: 5px; height: 5px; border-radius: 50%; margin: .15rem auto 0; }
+    .month-strip-day:hover { background: var(--accent); }
+    .month-strip-day.ms-today { background: var(--primary); color: #fff; }
+    .month-strip-day.ms-today .ms-num { color: #fff; }
+    .month-strip-day.ms-selected { outline: 2px solid var(--primary); outline-offset: 1px; }
+    .month-strip-day.ms-exam { }
+    .month-strip-day.ms-exam .ms-num { color: #fff; background: #111; border-radius: 50%; width: 22px; height: 22px; line-height: 22px; display: inline-block; }
+
+    /* ── Day details header upgrade ────────────────────────── */
+    .day-completion-ring {
+      width: 52px; height: 52px; flex-shrink: 0;
+    }
+    .day-completion-ring svg { width: 52px; height: 52px; transform: rotate(-90deg); }
+    .dcr-bg   { fill: none; stroke: var(--border); stroke-width: 4; }
+    .dcr-fill { fill: none; stroke-width: 4; stroke-linecap: round;
+                stroke: var(--primary);
+                transition: stroke-dashoffset .5s cubic-bezier(.4,0,.2,1); }
+    .dcr-text { font-size: .58rem; font-weight: 800; font-family: 'DM Mono', monospace;
+                fill: var(--foreground); text-anchor: middle; dominant-baseline: middle; }
+
   </style>
 </head>
 <body>
@@ -72,56 +342,83 @@
         </a>
         <div class="cal-header-info">
           <h1 class="cal-header-title">Study Calendar</h1>
-          <p class="cal-header-subtitle">Check off sessions to earn Study Score points ✓</p>
+          <p class="cal-header-subtitle">Check off sessions to earn Study Score points</p>
         </div>
       </div>
-      <a href="exams.html" class="btn-primary">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" x2="12" y1="5" y2="19"/><line x1="5" x2="19" y1="12" y2="12"/></svg>
-        Add Item
-      </a>
+      <div style="display:flex;gap:.6rem;align-items:center">
+        <button class="jump-today-btn" id="jumpToday">
+          <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="4" rx="2"/><line x1="16" x2="16" y1="2" y2="6"/><line x1="8" x2="8" y1="2" y2="6"/><line x1="3" x2="21" y1="10" y2="10"/><line x1="12" x2="12" y1="14" y2="18"/><line x1="10" x2="14" y1="16" y2="16"/></svg>
+          Today
+        </button>
+        <a href="exams.html" class="btn-primary">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" x2="12" y1="5" y2="19"/><line x1="5" x2="19" y1="12" y2="12"/></svg>
+          Add Item
+        </a>
+      </div>
     </div>
   </header>
 
   <main class="main-container">
-    <div class="week-navigation">
+
+    <!-- Week nav -->
+    <div class="week-nav-row week-navigation">
       <button class="nav-btn" id="prevWeek">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
-        Previous Week
+        Prev
       </button>
       <h2 class="week-range" id="weekRange">Loading…</h2>
       <button class="nav-btn" id="nextWeek">
-        Next Week
+        Next
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
       </button>
     </div>
 
+    <!-- Week progress -->
+    <div class="week-progress-label">
+      <span id="weekProgressLabel">This week</span>
+      <span id="weekProgressPct">0%</span>
+    </div>
+    <div class="week-progress-bar">
+      <div class="week-progress-fill" id="weekProgressFill" style="width:0%"></div>
+    </div>
+
+    <!-- Week summary strip -->
+    <div class="week-summary-strip" id="weekSummaryStrip">
+      <div class="wss-item"><div class="wss-dot" style="background:var(--success)"></div><span><strong id="wssCompleted">0</strong> done</span></div>
+      <div class="wss-item"><div class="wss-dot" style="background:var(--border)"></div><span><strong id="wssTotal">0</strong> sessions</span></div>
+      <div class="wss-item"><div class="wss-dot" style="background:var(--primary)"></div><span><strong id="wssHours">0h</strong> study time</span></div>
+      <div class="wss-item"><div class="wss-dot" style="background:#111"></div><span><strong id="wssExams">0</strong> exams this week</span></div>
+    </div>
+
+    <!-- Info grid -->
     <div class="info-grid">
       <div class="info-card">
         <div class="info-icon success">
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>
         </div>
-        <div class="info-content"><div class="info-label">Easy Exams</div><div class="info-value">5 hours prep</div></div>
+        <div class="info-content"><div class="info-label">Easy Exams</div><div class="info-value">5 hrs prep</div></div>
       </div>
       <div class="info-card">
         <div class="info-icon warning">
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
         </div>
-        <div class="info-content"><div class="info-label">Medium Exams</div><div class="info-value">10 hours prep</div></div>
+        <div class="info-content"><div class="info-label">Medium Exams</div><div class="info-value">10 hrs prep</div></div>
       </div>
       <div class="info-card">
         <div class="info-icon danger">
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>
         </div>
-        <div class="info-content"><div class="info-label">Hard Exams</div><div class="info-value">15 hours prep</div></div>
+        <div class="info-content"><div class="info-label">Hard Exams</div><div class="info-value">15 hrs prep</div></div>
       </div>
       <div class="info-card">
         <div class="info-icon very-danger">
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>
         </div>
-        <div class="info-content"><div class="info-label">Very Hard Exams</div><div class="info-value">20 hours prep</div></div>
+        <div class="info-content"><div class="info-label">Very Hard</div><div class="info-value">20 hrs prep</div></div>
       </div>
     </div>
 
+    <!-- Calendar layout -->
     <div class="calendar-layout">
       <div class="week-view-card">
         <div class="week-grid" id="weekGrid"></div>
@@ -132,9 +429,20 @@
             <h3 id="selectedDayName">Monday</h3>
             <p class="day-date" id="selectedDayDate">January 1, 2026</p>
           </div>
-          <div class="day-stats">
-            <div class="session-count" id="sessionCount">0</div>
-            <div class="session-label" id="sessionLabel">sessions</div>
+          <div style="display:flex;align-items:center;gap:.75rem">
+            <!-- Completion ring -->
+            <div class="day-completion-ring">
+              <svg viewBox="0 0 52 52">
+                <circle class="dcr-bg" cx="26" cy="26" r="22"/>
+                <circle class="dcr-fill" id="dcrFill" cx="26" cy="26" r="22"
+                  stroke-dasharray="138.23" stroke-dashoffset="138.23"/>
+                <text x="26" y="26" class="dcr-text" transform="rotate(90,26,26)" id="dcrText">0%</text>
+              </svg>
+            </div>
+            <div class="day-stats">
+              <div class="session-count" id="sessionCount">0</div>
+              <div class="session-label" id="sessionLabel">items</div>
+            </div>
           </div>
         </div>
         <div class="sessions-list" id="sessionsList"></div>
@@ -145,6 +453,7 @@
       </div>
     </div>
 
+    <!-- Legend -->
     <div class="legend">
       <div class="legend-item completed">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"/><path d="m9 12 2 2 4-4"/></svg>
@@ -154,8 +463,8 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/></svg>
         <span>Scheduled Study</span>
       </div>
-      <div class="legend-item exam">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>
+      <div class="legend-item exam" style="color:#111">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>
         <span>Exam Day</span>
       </div>
       <div class="legend-item" style="color:hsl(221,83%,53%)">

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -4,88 +4,102 @@ if (!currentUser) { window.location.replace('auth.html'); }
 else {
 
 const DIFFICULTY_HOURS = { easy: 5, medium: 10, hard: 15, 'very-hard': 20 };
-const DAILY_LIMIT = 2;
+const DAILY_LIMIT      = 2;
+const CIRCUMFERENCE    = 2 * Math.PI * 22; // for 52×52 SVG ring r=22 → ~138.2
 
 let currentWeekStart = getStartOfWeek(new Date());
 let selectedDate     = new Date();
 
-// Cache for generated schedule (regenerated when needed)
-let _scheduleCache   = null;
-
+// ── Utilities ─────────────────────────────────────────────────
 function getStartOfWeek(date) {
   const d = new Date(date);
   const day = d.getDay();
-  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-  d.setDate(diff); d.setHours(0,0,0,0);
+  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1));
+  d.setHours(0,0,0,0);
   return d;
 }
-
 function addDays(date, n) {
   const d = new Date(date); d.setDate(d.getDate() + n); return d;
 }
-
 function isSameDay(a, b) {
   return new Date(a).toDateString() === new Date(b).toDateString();
 }
-
 function fmtDate(date, fmt) {
   const d = new Date(date);
-  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-  const weekdays = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
-  const short    = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
-  if (fmt === 'MMM d')      return `${months[d.getMonth()]} ${d.getDate()}`;
-  if (fmt === 'MMM d, yyyy')return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
-  if (fmt === 'EEEE')       return weekdays[d.getDay()];
-  if (fmt === 'EEE')        return short[d.getDay()];
-  if (fmt === 'd')          return d.getDate().toString();
+  const months  = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  const weekdays= ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+  const short   = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+  if (fmt==='MMM d')       return `${months[d.getMonth()]} ${d.getDate()}`;
+  if (fmt==='MMM d, yyyy') return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
+  if (fmt==='EEEE')        return weekdays[d.getDay()];
+  if (fmt==='EEE')         return short[d.getDay()];
+  if (fmt==='d')           return d.getDate().toString();
+  if (fmt==='MMMM yyyy')   return `${['January','February','March','April','May','June','July','August','September','October','November','December'][d.getMonth()]} ${d.getFullYear()}`;
   return d.toDateString();
+}
+function diffColor(difficulty) {
+  if (difficulty==='very-hard') return 'very-danger';
+  if (difficulty==='hard')      return 'danger';
+  if (difficulty==='medium')    return 'warning';
+  return 'success';
 }
 
 // ── Schedule generator ────────────────────────────────────────
 function generateSchedule(items, sessions) {
-  const scheduled = [];
-  const today = new Date(); today.setHours(0,0,0,0);
+  const scheduled  = [];
+  const today      = new Date(); today.setHours(0,0,0,0);
   const dailySlots = {};
-  const START = 9 * 60;
-  const BREAK = 15;
+  const START      = 9 * 60;
+  const BREAK      = 15;
 
-  // Only generate study sessions for exam-type items
   items.filter(i => i.type === 'exam').forEach(exam => {
     try {
       const dateKey  = exam.dueDate || exam.examDate || '';
       const examDate = new Date(dateKey + 'T12:00:00');
       examDate.setHours(0,0,0,0);
       const daysUntil = Math.ceil((examDate - today) / 86400000);
+      const color     = diffColor(exam.difficulty);
+
+      // Exam-day marker
+      scheduled.push({
+        id: `examday-${exam.id}`, blockId: `examday-${exam.id}`,
+        subject: exam.subject, topic: exam.topic || '',
+        time: '—', durationMinutes: 0, duration: '—',
+        color: 'exam-day', type: 'exam-day',
+        date: new Date(examDate), examId: exam.id,
+        difficulty: exam.difficulty
+      });
+
       if (daysUntil <= 0) return;
 
       const totalH   = DIFFICULTY_HOURS[exam.difficulty] || 10;
-      const studiedH = sessions.filter(s => s.subject === exam.subject).reduce((sum, s) => sum + s.duration/60, 0);
+      const studiedH = sessions.filter(s => s.subject === exam.subject)
+                               .reduce((sum,s) => sum + s.duration/60, 0);
       let hoursLeft  = Math.max(0, totalH - studiedH);
       if (hoursLeft <= 0) return;
 
-      for (let i = 0; i < daysUntil && hoursLeft > 0; i++) {
-        const day    = addDays(today, i);
+      const daysNeeded   = Math.ceil(hoursLeft / DAILY_LIMIT);
+      const daysToUse    = Math.min(daysNeeded, daysUntil);
+      const scheduleFrom = addDays(examDate, -daysToUse);
+      scheduleFrom.setHours(0,0,0,0);
+      const startFrom  = scheduleFrom < today ? today : scheduleFrom;
+      const actualDays = Math.ceil((examDate - startFrom) / 86400000);
+      if (actualDays <= 0) return;
+
+      for (let i = 0; i < actualDays && hoursLeft > 0; i++) {
+        const day    = addDays(startFrom, i);
         const dayKey = day.toISOString().split('T')[0];
         if (!dailySlots[dayKey]) dailySlots[dayKey] = START;
 
-        const daysRemaining = daysUntil - i;
-        let sessionH;
-        if (daysRemaining === 1) sessionH = Math.min(DAILY_LIMIT, hoursLeft);
-        else {
-          const avg = hoursLeft / daysRemaining;
-          sessionH = avg <= 1 ? Math.min(1, hoursLeft) : Math.min(DAILY_LIMIT, hoursLeft);
-        }
-        if (sessionH < 0.5) continue;
+        const daysRemaining = actualDays - i;
+        const sessionH = Math.min(DAILY_LIMIT, Math.ceil((hoursLeft / daysRemaining) * 2) / 2);
+        if (sessionH < 0.5) { hoursLeft = 0; break; }
 
         const mins     = Math.round(sessionH * 60);
         const startMin = dailySlots[dayKey];
         const h = Math.floor(startMin/60).toString().padStart(2,'0');
         const m = (startMin%60).toString().padStart(2,'0');
         const blockId  = `sched-${exam.id}-${dayKey}`;
-        const color    = exam.difficulty === 'very-hard' ? 'very-danger'
-                       : exam.difficulty === 'hard'      ? 'danger'
-                       : exam.difficulty === 'medium'    ? 'warning'
-                                                         : 'success';
 
         scheduled.push({
           id: blockId, blockId,
@@ -93,8 +107,8 @@ function generateSchedule(items, sessions) {
           time: `${h}:${m}`, durationMinutes: mins,
           duration: `${mins} min`,
           color, type: 'scheduled',
-          date: new Date(day),
-          examId: exam.id
+          date: new Date(day), examId: exam.id,
+          difficulty: exam.difficulty
         });
 
         dailySlots[dayKey] = startMin + mins + BREAK;
@@ -103,41 +117,31 @@ function generateSchedule(items, sessions) {
     } catch(e) { console.error(e); }
   });
 
-  // Add reminder/project "event" blocks on their due date and reminder-notify days
   items.filter(i => i.type !== 'exam').forEach(item => {
     try {
-      const dateKey  = item.dueDate || item.examDate || '';
-      const dueDate  = new Date(dateKey + 'T12:00:00');
+      const dateKey = item.dueDate || item.examDate || '';
+      const dueDate = new Date(dateKey + 'T12:00:00');
       dueDate.setHours(0,0,0,0);
       if (dueDate < today) return;
-
       const color = item.type === 'project' ? 'project' : 'reminder';
 
-      // Push event on due day
       scheduled.push({
-        id: `event-${item.id}-due`,
-        blockId: `event-${item.id}-due`,
+        id: `event-${item.id}-due`, blockId: `event-${item.id}-due`,
         subject: item.subject, topic: item.topic,
-        time: '—', durationMinutes: 0,
-        duration: '—',
+        time: '—', durationMinutes: 0, duration: '—',
         color, type: item.type,
-        date: new Date(dueDate),
-        notes: item.notes || ''
+        date: new Date(dueDate), notes: item.notes || ''
       });
 
-      // Reminder: also push a notify block N days before
       if (item.type === 'reminder' && item.reminderDaysBefore > 0) {
         const notifyDate = addDays(dueDate, -item.reminderDaysBefore);
         if (notifyDate >= today) {
           scheduled.push({
-            id: `event-${item.id}-notify`,
-            blockId: `event-${item.id}-notify`,
+            id: `event-${item.id}-notify`, blockId: `event-${item.id}-notify`,
             subject: `Reminder: ${item.subject}`, topic: item.topic,
-            time: '—', durationMinutes: 0,
-            duration: '—',
+            time: '—', durationMinutes: 0, duration: '—',
             color: 'reminder-notify', type: 'reminder-notify',
-            date: new Date(notifyDate),
-            notes: item.notes || ''
+            date: new Date(notifyDate), notes: item.notes || ''
           });
         }
       }
@@ -151,26 +155,21 @@ function generateSchedule(items, sessions) {
 function showScoreToast(points) {
   const t = document.createElement('div');
   t.className = 'cal-score-toast';
-  t.innerHTML = `+${points} pts <span style="font-size:.85em;opacity:.8">Study Score</span>`;
+  t.innerHTML = `+${points} pts <span style="font-size:.85em;opacity:.75">Study Score</span>`;
   document.body.appendChild(t);
   requestAnimationFrame(() => t.classList.add('visible'));
-  setTimeout(() => { t.classList.remove('visible'); setTimeout(() => t.remove(), 400); }, 2200);
+  setTimeout(() => { t.classList.remove('visible'); setTimeout(() => t.remove(), 400); }, 2400);
 }
 
 // ── Toggle completion ──────────────────────────────────────────
 function toggleComplete(blockId, subject, durationMinutes) {
-  const alreadyDone = DB.isCompleted(currentUser.id, blockId);
-  if (alreadyDone) {
+  if (DB.isCompleted(currentUser.id, blockId)) {
     DB.uncompleteBlock(currentUser.id, blockId);
-    refresh();
-    return;
+  } else {
+    const gained = DB.completeBlock(currentUser.id, blockId, { subject, durationMinutes });
+    if (gained) showScoreToast(Math.round(durationMinutes * 1.5));
   }
-  const gained = DB.completeBlock(currentUser.id, blockId, { subject, durationMinutes });
-  if (gained) {
-    const pts = Math.round(durationMinutes * 1.5);
-    showScoreToast(pts);
-    refresh();
-  }
+  refresh();
 }
 
 // ── Week nav ───────────────────────────────────────────────────
@@ -180,33 +179,80 @@ function renderWeekNav() {
     `${fmtDate(currentWeekStart,'MMM d')} – ${fmtDate(end,'MMM d, yyyy')}`;
 }
 
+// ── Week progress + summary ────────────────────────────────────
+function renderWeekProgress(scheduled) {
+  // Build set of ISO date strings for the current week
+  const weekDays = new Set();
+  for (let i = 0; i < 7; i++) weekDays.add(addDays(currentWeekStart, i).toISOString().split('T')[0]);
+
+  const inWeek = s => weekDays.has(new Date(s.date).toISOString().split('T')[0]);
+
+  const studyBlocks   = scheduled.filter(s => s.type === 'scheduled' && inWeek(s));
+  const total         = studyBlocks.length;
+  const completed     = studyBlocks.filter(s => DB.isCompleted(currentUser.id, s.blockId)).length;
+  const pct           = total > 0 ? Math.round((completed / total) * 100) : 0;
+  const totalMins     = studyBlocks.reduce((sum,s) => sum + (s.durationMinutes||0), 0);
+  const examsThisWeek = scheduled.filter(s => s.type === 'exam-day' && inWeek(s)).length;
+
+  document.getElementById('weekProgressFill').style.width = pct + '%';
+  document.getElementById('weekProgressPct').textContent  = pct + '%';
+  document.getElementById('weekProgressLabel').textContent =
+    `Week progress — ${completed} of ${total} sessions done`;
+
+  document.getElementById('wssCompleted').textContent = completed;
+  document.getElementById('wssTotal').textContent     = total;
+  const h = Math.floor(totalMins/60), m = totalMins%60;
+  document.getElementById('wssHours').textContent = h > 0 ? `${h}h ${m}m` : `${m}m`;
+  document.getElementById('wssExams').textContent  = examsThisWeek;
+}
+
 // ── Week grid ──────────────────────────────────────────────────
 function renderWeekGrid(items, sessions, scheduled) {
   const grid = document.getElementById('weekGrid');
   grid.innerHTML = '';
+  const CIRC_SMALL = 2 * Math.PI * 9; // r=9 for the small day-cell rings
+
   for (let i = 0; i < 7; i++) {
-    const date       = addDays(currentWeekStart, i);
-    const daySessions = sessions.filter(s => isSameDay(new Date(s.completedAt), date)).map(s => ({...s, color:'success'}));
+    const date        = addDays(currentWeekStart, i);
     const dayScheduled = scheduled.filter(s => isSameDay(s.date, date));
-    const all = [...daySessions, ...dayScheduled];
+    const studyBlocks  = dayScheduled.filter(b => b.type === 'scheduled');
+    const doneCount    = studyBlocks.filter(b => DB.isCompleted(currentUser.id, b.blockId)).length;
+    const hasExam      = dayScheduled.some(b => b.type === 'exam-day');
+    const pct          = studyBlocks.length > 0 ? doneCount / studyBlocks.length : 0;
+    const offset       = CIRC_SMALL - pct * CIRC_SMALL;
+    const ringColor    = pct === 1 ? 'var(--success)' : 'var(--primary)';
 
     const cell = document.createElement('button');
     cell.className = 'day-cell';
     if (isSameDay(date, selectedDate)) cell.classList.add('selected');
     if (isSameDay(date, new Date()))   cell.classList.add('today');
+    if (hasExam)                       cell.classList.add('exam-day-cell');
 
-    // Count completed vs total study blocks
-    const studyBlocks = dayScheduled.filter(b => b.type === 'scheduled');
-    const doneCount   = studyBlocks.filter(b => DB.isCompleted(currentUser.id, b.blockId)).length;
+    const indicators = dayScheduled.slice(0,3).map(s =>
+      `<div class="indicator-bar ${s.color}"></div>`).join('') +
+      (dayScheduled.length > 3 ? `<div class="more-indicator">+${dayScheduled.length-3}</div>` : '');
+
+    const ringHtml = studyBlocks.length > 0 ? `
+      <div class="day-ring-wrap">
+        <svg viewBox="0 0 22 22">
+          <circle class="day-ring-bg"   cx="11" cy="11" r="9"/>
+          <circle class="day-ring-fill" cx="11" cy="11" r="9"
+            stroke="${hasExam ? 'rgba(255,255,255,.7)' : ringColor}"
+            stroke-dasharray="${CIRC_SMALL.toFixed(1)}"
+            stroke-dashoffset="${offset.toFixed(1)}"/>
+        </svg>
+      </div>` : '';
 
     cell.innerHTML = `
+      ${ringHtml}
       <div class="day-name">${fmtDate(date,'EEE')}</div>
       <div class="day-number">${fmtDate(date,'d')}</div>
-      <div class="day-indicators">
-        ${all.slice(0,3).map(s => `<div class="indicator-bar ${s.color}"></div>`).join('')}
-        ${all.length > 3 ? `<div class="more-indicator">+${all.length-3}</div>` : ''}
-      </div>
-      ${studyBlocks.length > 0 ? `<div class="day-prog-text">${doneCount}/${studyBlocks.length}</div>` : ''}`;
+      <div class="day-indicators">${indicators}</div>
+      ${hasExam
+        ? `<div class="exam-day-pill">Exam</div>`
+        : studyBlocks.length > 0
+          ? `<div class="day-prog-text">${doneCount}/${studyBlocks.length}</div>`
+          : ''}`;
 
     cell.addEventListener('click', () => {
       selectedDate = date;
@@ -222,26 +268,28 @@ function renderDayDetails(items, sessions, scheduled) {
   document.getElementById('selectedDayName').textContent = fmtDate(selectedDate,'EEEE');
   document.getElementById('selectedDayDate').textContent = fmtDate(selectedDate,'MMM d, yyyy');
 
-  const daySessions = sessions.filter(s => isSameDay(new Date(s.completedAt), selectedDate)).map(s => ({
-    subject: s.subject || 'General Study',
-    topic: 'Timer study session',
-    time: new Date(s.completedAt).toTimeString().slice(0,5),
-    durationMinutes: s.duration,
-    duration: `${s.duration} min`,
-    completed: true, type: 'session', blockId: null
-  }));
+  const daySessions = sessions
+    .filter(s => isSameDay(new Date(s.completedAt), selectedDate))
+    .map(s => ({
+      subject: s.subject || 'General Study',
+      topic: 'Timer study session',
+      time: new Date(s.completedAt).toTimeString().slice(0,5),
+      durationMinutes: s.duration,
+      duration: `${s.duration} min`,
+      completed: true, type: 'session', blockId: null, color: 'success'
+    }));
 
   const dayScheduled = scheduled.filter(s => isSameDay(s.date, selectedDate));
-
-  // Mark completions
-  const enriched = dayScheduled.map(b => ({
+  const enriched     = dayScheduled.map(b => ({
     ...b,
     completed: b.type === 'scheduled' ? DB.isCompleted(currentUser.id, b.blockId) : false
   }));
 
   const all = [...enriched, ...daySessions].sort((a,b) => {
-    if (a.type === 'exam' || a.type === 'project') return -1;
-    if (b.type === 'exam' || b.type === 'project') return  1;
+    if (a.type === 'exam-day') return -1;
+    if (b.type === 'exam-day') return  1;
+    if (a.type === 'project')  return -1;
+    if (b.type === 'project')  return  1;
     const ta = a.time === '—' ? '00:00' : a.time;
     const tb = b.time === '—' ? '00:00' : b.time;
     return ta.localeCompare(tb);
@@ -250,80 +298,171 @@ function renderDayDetails(items, sessions, scheduled) {
   document.getElementById('sessionCount').textContent = all.length;
   document.getElementById('sessionLabel').textContent  = all.length === 1 ? 'item' : 'items';
 
+  // Update completion ring — only count actual study blocks
+  const studyAll = all.filter(s => s.type === 'scheduled' || s.type === 'session');
+  const doneAll  = studyAll.filter(s => s.completed).length;
+  const ringPct  = studyAll.length > 0 ? doneAll / studyAll.length : 0;
+  const dcrFill  = document.getElementById('dcrFill');
+  const dcrText  = document.getElementById('dcrText');
+  const circ     = 2 * Math.PI * 22; // matches r=22 in the SVG
+  dcrFill.setAttribute('stroke-dasharray',  circ.toFixed(1));
+  dcrFill.setAttribute('stroke-dashoffset', (circ - ringPct * circ).toFixed(1));
+  dcrFill.style.stroke = ringPct === 1 ? 'var(--success)' : 'var(--primary)';
+  dcrText.textContent  = Math.round(ringPct * 100) + '%';
+
   const list = document.getElementById('sessionsList');
   if (all.length === 0) {
-    list.innerHTML = `<div class="empty-state"><svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg><p>Nothing scheduled for this day</p></div>`;
+    list.innerHTML = `
+      <div class="empty-state">
+        <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        <p>Nothing scheduled for this day</p>
+      </div>`;
     document.getElementById('daySummary').style.display = 'none';
     return;
   }
 
   list.innerHTML = all.map((s, idx) => {
-    const isStudy = s.type === 'scheduled';
-    const isDone  = s.completed;
-    const scoreGain = isStudy ? Math.round((s.durationMinutes || 0) * 1.5) : 0;
+    const isStudy  = s.type === 'scheduled';
+    const isDone   = s.completed;
+    const scoreGain = isStudy ? Math.round((s.durationMinutes||0) * 1.5) : 0;
 
-    // Type label + icon
-    let typeBadge = '';
-    let typeIcon  = '';
+    // ── Exam day banner ─────────────────────────────────────
+    if (s.type === 'exam-day') {
+      return `
+        <div class="exam-day-block" style="animation-delay:${idx*.05}s">
+          <div class="exam-day-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/>
+              <polyline points="10 2 10 10 13 7 16 10 16 2"/>
+            </svg>
+          </div>
+          <div>
+            <div class="exam-day-label">Exam Today</div>
+            <div>${s.subject}${s.topic ? ' — ' + s.topic : ''}</div>
+          </div>
+        </div>`;
+    }
+
+    // ── Project card ─────────────────────────────────────────
+    if (s.type === 'project') {
+      return `
+        <div class="event-card event-card--project" style="animation-delay:${idx*.05}s">
+          <div class="event-card__accent"></div>
+          <div class="event-card__icon">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/>
+            </svg>
+          </div>
+          <div class="event-card__body">
+            <div class="event-card__label">Project Due</div>
+            <div class="event-card__subject">${s.subject}</div>
+            ${s.topic ? `<div class="event-card__topic">${s.topic}</div>` : ''}
+            ${s.notes ? `<div class="event-card__notes">${s.notes}</div>` : ''}
+          </div>
+          <div class="event-card__badge">DUE</div>
+        </div>`;
+    }
+
+    // ── Reminder card ────────────────────────────────────────
+    if (s.type === 'reminder') {
+      return `
+        <div class="event-card event-card--reminder" style="animation-delay:${idx*.05}s">
+          <div class="event-card__accent"></div>
+          <div class="event-card__icon">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+            </svg>
+          </div>
+          <div class="event-card__body">
+            <div class="event-card__label">Reminder</div>
+            <div class="event-card__subject">${s.subject}</div>
+            ${s.topic ? `<div class="event-card__topic">${s.topic}</div>` : ''}
+            ${s.notes ? `<div class="event-card__notes">${s.notes}</div>` : ''}
+          </div>
+          <div class="event-card__badge">TODAY</div>
+        </div>`;
+    }
+
+    // ── Reminder notify card ─────────────────────────────────
+    if (s.type === 'reminder-notify') {
+      return `
+        <div class="event-card event-card--notify" style="animation-delay:${idx*.05}s">
+          <div class="event-card__accent"></div>
+          <div class="event-card__icon">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+            </svg>
+          </div>
+          <div class="event-card__body">
+            <div class="event-card__label">Upcoming Reminder</div>
+            <div class="event-card__subject">${s.subject.replace('Reminder: ','')}</div>
+            ${s.topic ? `<div class="event-card__topic">${s.topic}</div>` : ''}
+            ${s.notes ? `<div class="event-card__notes">${s.notes}</div>` : ''}
+          </div>
+          <div class="event-card__badge">SOON</div>
+        </div>`;
+    }
+
+    // ── Study session / timer session ────────────────────────
+    let typeIcon = '';
     if (s.type === 'session') {
       typeIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"/><path d="m9 12 2 2 4-4"/></svg>`;
-      typeBadge = '';
-    } else if (s.type === 'scheduled') {
+    } else {
       typeIcon = isDone
         ? `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"/><path d="m9 12 2 2 4-4"/></svg>`
         : `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/></svg>`;
-      typeBadge = `<span class="session-badge scheduled">Study</span>`;
-    } else if (s.type === 'project') {
-      typeIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>`;
-      typeBadge = `<span class="session-badge" style="background:rgba(59,130,246,.12);color:hsl(221,83%,53%)">Project</span>`;
-    } else if (s.type === 'reminder') {
-      typeIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>`;
-      typeBadge = `<span class="session-badge" style="background:rgba(234,179,8,.12);color:hsl(38,80%,40%)">Reminder</span>`;
-    } else if (s.type === 'reminder-notify') {
-      typeIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>`;
-      typeBadge = `<span class="session-badge" style="background:rgba(239,68,68,.12);color:var(--destructive)">Notify</span>`;
     }
 
+    const diffDot = isStudy && s.color
+      ? `<span class="diff-dot ${s.color}"></span>` : '';
+
+    const typeBadge = s.type === 'scheduled'
+      ? `<span class="session-badge scheduled">Study</span>` : '';
+
     const checkBtn = isStudy ? `
-      <button class="cal-check-btn ${isDone ? 'done' : ''}"
+      <button class="cal-check-btn ${isDone?'done':''}"
         onclick="toggleComplete('${s.blockId}','${(s.subject||'').replace(/'/g,"\\'")}',${s.durationMinutes||0})"
-        title="${isDone ? 'Mark incomplete' : 'Mark complete'}">
+        title="${isDone?'Mark incomplete':'Mark complete'}">
         ${isDone
-          ? `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>`
-          : `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/></svg>`
-        }
+          ? `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>`
+          : `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/></svg>`}
         ${isDone ? 'Done' : 'Mark done'}
       </button>` : '';
 
     const scoreTag = isStudy && !isDone
-      ? `<div class="cal-score-tag">+${scoreGain} pts on complete</div>`
-      : isDone ? `<div class="cal-score-tag done">✓ +${scoreGain} pts earned</div>` : '';
+      ? `<div class="cal-score-tag"><svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>+${scoreGain} pts on complete</div>`
+      : isDone
+        ? `<div class="cal-score-tag done"><svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6 9 17l-5-5"/></svg>+${scoreGain} pts earned</div>`
+        : '';
+
+    const cardClass = isDone ? 'completed'
+      : s.type === 'session' ? 'completed' : 'scheduled-item';
 
     return `
-      <div class="session-item ${isDone ? 'completed' : s.type === 'session' ? 'completed' : 'scheduled-item'}" style="animation-delay:${idx*.05}s">
+      <div class="session-item ${cardClass}" data-color="${s.color||''}" style="animation-delay:${idx*.05}s">
         <div class="session-content">
           <div class="session-left">
-            <div class="session-icon ${isDone ? 'completed' : s.type}">${typeIcon}</div>
+            <div class="session-icon ${isDone?'completed':s.type}">${typeIcon}</div>
             <div class="session-info">
-              <div class="session-subject">${s.subject}${typeBadge}</div>
-              <div class="session-topic">${s.topic}</div>
-              ${s.notes ? `<div style="font-size:.72rem;color:var(--muted-foreground);margin-top:.15rem;font-style:italic">${s.notes}</div>` : ''}
+              <div class="session-subject">${diffDot}${s.subject}${typeBadge}</div>
+              <div class="session-topic">${s.topic||''}</div>
               ${scoreTag}
             </div>
           </div>
           <div class="session-right">
             <div class="session-time">${s.time}</div>
-            ${s.duration !== '—' ? `<div class="session-duration"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>${s.duration}</div>` : ''}
+            ${s.duration!=='—' ? `<div class="session-duration"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>${s.duration}</div>` : ''}
             ${checkBtn}
           </div>
         </div>
       </div>`;
   }).join('');
 
-  const studyItems = all.filter(s => s.type === 'scheduled' || s.type === 'session');
-  const totalMins  = studyItems.reduce((sum, s) => sum + (s.durationMinutes || parseInt(s.duration) || 0), 0);
+  const studyItems = all.filter(s => s.type==='scheduled' || s.type==='session');
+  const totalMins  = studyItems.reduce((sum,s) => sum + (s.durationMinutes || parseInt(s.duration)||0), 0);
   const h = Math.floor(totalMins/60), m = totalMins%60;
-  document.getElementById('totalTime').textContent    = h > 0 ? `${h}h ${m}m` : `${m}m`;
+  document.getElementById('totalTime').textContent =
+    h > 0 ? `${h}h ${m}m` : `${m}m`;
   document.getElementById('completedCount').textContent =
     `${all.filter(s => s.completed).length} / ${studyItems.length}`;
   document.getElementById('daySummary').style.display = 'block';
@@ -332,14 +471,15 @@ function renderDayDetails(items, sessions, scheduled) {
 // ── Full refresh ───────────────────────────────────────────────
 function refresh() {
   const items    = DB.getItems(currentUser.id);
-  const exams    = DB.getExams(currentUser.id);  // legacy compat
-  // Merge legacy exams not already in items
+  const exams    = DB.getExams(currentUser.id);
   const itemIds  = new Set(items.map(i => i.id));
-  const allItems = [...items, ...exams.filter(e => !itemIds.has(e.id)).map(e => ({...e, type:'exam', dueDate: e.examDate}))];
-  const sessions = DB.getSessions(currentUser.id);
+  const allItems = [...items, ...exams.filter(e => !itemIds.has(e.id))
+                                       .map(e => ({...e, type:'exam', dueDate: e.examDate}))];
+  const sessions  = DB.getSessions(currentUser.id);
   const scheduled = generateSchedule(allItems, sessions);
 
   renderWeekNav();
+  renderWeekProgress(scheduled);
   renderWeekGrid(allItems, sessions, scheduled);
   renderDayDetails(allItems, sessions, scheduled);
 }
@@ -353,6 +493,11 @@ function init() {
   });
   document.getElementById('nextWeek').addEventListener('click', () => {
     currentWeekStart = addDays(currentWeekStart, 7);
+    refresh();
+  });
+  document.getElementById('jumpToday').addEventListener('click', () => {
+    currentWeekStart = getStartOfWeek(new Date());
+    selectedDate     = new Date();
     refresh();
   });
 }

--- a/js/config.js
+++ b/js/config.js
@@ -11,7 +11,7 @@ const SITE_CONFIG = {
   mobileBreakpoint:  768,
 
   // ── Disable right-click context menu ──
-  disableRightClick: true,
+  disableRightClick: false,
 
   // ── Page paths ──
   pages: {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -4,6 +4,11 @@ if (!currentUser) { window.location.replace('auth.html'); }
 
 else {
 
+// ── Shared constants (must match calendar.js) ─────────────────
+const DIFFICULTY_HOURS = { easy: 5, medium: 10, hard: 15, 'very-hard': 20 };
+const DAILY_LIMIT      = 2; // max study hours per day
+
+// ── Helpers ────────────────────────────────────────────────────
 function getTimeGreeting() {
   const h = new Date().getHours();
   if (h < 12) return 'Good morning';
@@ -28,106 +33,229 @@ function formatDate(date) {
 }
 
 function formatDateReadable(dateStr) {
-  return new Date(dateStr + 'T12:00:00').toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+  return new Date(dateStr + 'T12:00:00').toLocaleDateString('en-US', {
+    year: 'numeric', month: 'short', day: 'numeric'
+  });
 }
 
+// ── Core schedule generator (mirrors calendar.js logic exactly) ─
+// Returns all scheduled blocks for ALL days. Caller filters to today.
+function generateAllScheduled(items, sessions) {
+  const scheduled = [];
+  const today     = new Date(); today.setHours(0, 0, 0, 0);
+  const dailySlots = {};
+  const START      = 9 * 60; // 09:00 in minutes
+  const BREAK      = 15;     // minutes between sessions
+
+  items.filter(i => i.type === 'exam').forEach(exam => {
+    try {
+      const dateKey  = exam.dueDate || exam.examDate || '';
+      const examDate = new Date(dateKey + 'T12:00:00');
+      examDate.setHours(0, 0, 0, 0);
+      const daysUntil = Math.ceil((examDate - today) / 86400000);
+
+      // Always push an exam-day marker
+      scheduled.push({
+        subject: exam.subject,
+        topic:   exam.topic || '',
+        type:    'exam-day',
+        date:    new Date(examDate),
+      });
+
+      if (daysUntil <= 0) return;
+
+      const totalH   = DIFFICULTY_HOURS[exam.difficulty] || 10;
+      const studiedH = sessions
+        .filter(s => s.subject === exam.subject)
+        .reduce((sum, s) => sum + s.duration / 60, 0);
+      let hoursLeft  = Math.max(0, totalH - studiedH);
+      if (hoursLeft <= 0) return;
+
+      // Work backwards: exactly as many consecutive days as needed
+      const daysNeeded   = Math.ceil(hoursLeft / DAILY_LIMIT);
+      const daysToUse    = Math.min(daysNeeded, daysUntil);
+      const idealStart   = new Date(examDate);
+      idealStart.setDate(idealStart.getDate() - daysToUse);
+      idealStart.setHours(0, 0, 0, 0);
+      const startFrom    = idealStart < today ? today : idealStart;
+      const actualDays   = Math.ceil((examDate - startFrom) / 86400000);
+      if (actualDays <= 0) return;
+
+      for (let i = 0; i < actualDays && hoursLeft > 0; i++) {
+        const day    = new Date(startFrom);
+        day.setDate(day.getDate() + i);
+        const dayKey = day.toISOString().split('T')[0];
+        if (!dailySlots[dayKey]) dailySlots[dayKey] = START;
+
+        const daysRemaining = actualDays - i;
+        const sessionH = Math.min(
+          DAILY_LIMIT,
+          Math.ceil((hoursLeft / daysRemaining) * 2) / 2
+        );
+        if (sessionH < 0.5) { hoursLeft = 0; break; }
+
+        const mins     = Math.round(sessionH * 60);
+        const startMin = dailySlots[dayKey];
+        const hh = Math.floor(startMin / 60).toString().padStart(2, '0');
+        const mm = (startMin % 60).toString().padStart(2, '0');
+
+        scheduled.push({
+          subject:         exam.subject,
+          topic:           exam.topic || '',
+          time:            `${hh}:${mm}`,
+          durationMinutes: mins,
+          duration:        `${mins} min`,
+          type:            'scheduled',
+          date:            new Date(day),
+          examId:          exam.id,
+        });
+
+        dailySlots[dayKey] = startMin + mins + BREAK;
+        hoursLeft -= sessionH;
+      }
+    } catch (e) { console.error(e); }
+  });
+
+  return scheduled;
+}
+
+// ── Stats ──────────────────────────────────────────────────────
 function updateStats(stats, sessions) {
-  const studyScore = Math.floor((stats.totalStudyHours || 0) * 100);
-  document.getElementById('studyScore').textContent = studyScore;
-  document.getElementById('streak').textContent = stats.streak || 0;
+  // Study score is stored directly on stats (incremented by both timer & calendar blocks)
+  document.getElementById('studyScore').textContent = stats.studyScore || 0;
+  document.getElementById('streak').textContent     = stats.streak || 0;
 
-  const today = new Date().toDateString();
-  const todaySessions = sessions.filter(s => new Date(s.completedAt).toDateString() === today);
-  const todayHours = todaySessions.reduce((sum, s) => sum + (s.duration / 60), 0);
-  document.getElementById('todayHours').textContent = todayHours.toFixed(1);
-
+  const today     = new Date().toDateString();
   const weekStart = getWeekStart();
-  const weekSessions = sessions.filter(s => new Date(s.completedAt) >= weekStart);
-  const weekHours = weekSessions.reduce((sum, s) => sum + (s.duration / 60), 0);
-  const weeklyGoal = Math.min(100, Math.floor((weekHours / 20) * 100));
+
+  // Timer sessions
+  const todaySessions = sessions.filter(s => new Date(s.completedAt).toDateString() === today);
+  const weekSessions  = sessions.filter(s => new Date(s.completedAt) >= weekStart);
+
+  // Calendar block completions (checked off in calendar.js)
+  const completions      = DB.getCompletions(currentUser.id);
+  const todayCompletions = completions.filter(c => new Date(c.completedAt).toDateString() === today);
+  const weekCompletions  = completions.filter(c => new Date(c.completedAt) >= weekStart);
+
+  // Studied Today = timer minutes + calendar block minutes
+  const todayMins =
+    todaySessions.reduce((sum, s) => sum + (s.duration || 0), 0) +
+    todayCompletions.reduce((sum, c) => sum + (c.durationMinutes || 0), 0);
+  document.getElementById('todayHours').textContent = (todayMins / 60).toFixed(1);
+
+  // Weekly Goal = timer hours + calendar block hours
+  const weekMins =
+    weekSessions.reduce((sum, s) => sum + (s.duration || 0), 0) +
+    weekCompletions.reduce((sum, c) => sum + (c.durationMinutes || 0), 0);
+  const weeklyGoal = Math.min(100, Math.floor((weekMins / 60 / 20) * 100));
   document.getElementById('goalPercentage').textContent = weeklyGoal + '%';
-  document.getElementById('progressFill').style.width = weeklyGoal + '%';
+  document.getElementById('progressFill').style.width   = weeklyGoal + '%';
 }
 
-function updateSchedule(exams, sessions) {
+// ── Today's schedule ───────────────────────────────────────────
+function updateSchedule(items, sessions) {
   const scheduleList = document.getElementById('scheduleList');
-  const todaySchedule = [];
-  const today = new Date().toDateString();
-  const todayISO = formatDate(new Date());
+  const today        = new Date(); today.setHours(0, 0, 0, 0);
+  const todayStr     = today.toDateString();
 
-  const todayExams = exams.filter(e => e.examDate === todayISO).map(e => ({
-    time: '09:00', subject: e.subject, topic: e.topic, duration: '2 hours', type: 'exam'
-  }));
-  todaySchedule.push(...todayExams);
+  // Generate full schedule and filter to today
+  const allScheduled = generateAllScheduled(items, sessions);
+  const isSameDay    = (a, b) => new Date(a).toDateString() === new Date(b).toDateString();
 
-  const todaySessions = sessions.filter(s => new Date(s.completedAt).toDateString() === today).map(s => ({
-    time: new Date(s.completedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-    subject: s.subject || 'General Study',
-    topic: 'Study session',
-    duration: `${s.duration} min`,
-    type: 'completed'
-  }));
-  todaySchedule.push(...todaySessions);
+  const todayItems = [];
 
-  const now = new Date();
-  now.setHours(0, 0, 0, 0);
-  let currentSlot = 9 * 60;
-  exams.forEach(exam => {
-    const examDate = new Date(exam.examDate + 'T12:00:00');
-    examDate.setHours(0, 0, 0, 0);
-    const daysUntil = Math.ceil((examDate - now) / 86400000);
-    if (daysUntil <= 0) return;
-    const diffHours = { easy: 5, medium: 10, hard: 15, 'very-hard': 20 };
-    const totalH = diffHours[exam.difficulty] || 10;
-    const studiedH = sessions.filter(s => s.subject === exam.subject).reduce((sum, s) => sum + s.duration / 60, 0);
-    const remaining = Math.max(0, totalH - studiedH);
-    if (remaining <= 0) return;
-    const sessionH = daysUntil === 1 ? Math.min(2, remaining) : Math.min(2, remaining / Math.min(daysUntil, 7));
-    if (sessionH < 0.5) return;
-    const mins = Math.round(sessionH * 60);
-    const h = Math.floor(currentSlot / 60).toString().padStart(2, '0');
-    const m = (currentSlot % 60).toString().padStart(2, '0');
-    currentSlot += mins + 15;
-    todaySchedule.push({ time: `${h}:${m}`, subject: exam.subject, topic: exam.topic, duration: `${mins} min`, type: 'scheduled' });
+  // 1. Exam day marker for today
+  allScheduled
+    .filter(s => s.type === 'exam-day' && isSameDay(s.date, today))
+    .forEach(s => todayItems.push({
+      time:     '—',
+      subject:  s.subject,
+      topic:    s.topic,
+      duration: '—',
+      type:     'exam-day',
+    }));
+
+  // 2. Generated study sessions for today
+  allScheduled
+    .filter(s => s.type === 'scheduled' && isSameDay(s.date, today))
+    .forEach(s => todayItems.push({
+      time:     s.time,
+      subject:  s.subject,
+      topic:    s.topic,
+      duration: s.duration,
+      type:     'scheduled',
+    }));
+
+  // 3. Completed timer sessions from today
+  sessions
+    .filter(s => new Date(s.completedAt).toDateString() === todayStr)
+    .forEach(s => todayItems.push({
+      time:     new Date(s.completedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      subject:  s.subject || 'General Study',
+      topic:    'Study session',
+      duration: `${s.duration} min`,
+      type:     'completed',
+    }));
+
+  // Sort: exam-day first, then by time
+  todayItems.sort((a, b) => {
+    if (a.type === 'exam-day') return -1;
+    if (b.type === 'exam-day') return  1;
+    const ta = a.time === '—' ? '00:00' : a.time;
+    const tb = b.time === '—' ? '00:00' : b.time;
+    return ta.localeCompare(tb);
   });
 
-  todaySchedule.sort((a, b) => {
-    if (a.type === 'exam') return -1;
-    if (b.type === 'exam') return 1;
-    return a.time.localeCompare(b.time);
-  });
-
-  if (todaySchedule.length === 0) {
+  if (todayItems.length === 0) {
     scheduleList.innerHTML = `
       <div class="empty-state">
         <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="4" rx="2" ry="2"></rect><line x1="16" x2="16" y1="2" y2="6"></line><line x1="8" x2="8" y1="2" y2="6"></line><line x1="3" x2="21" y1="10" y2="10"></line></svg>
         <p>No activities scheduled for today</p>
         <a href="timer.html" class="btn-outline btn-sm">Start a study session</a>
       </div>`;
-  } else {
-    scheduleList.innerHTML = todaySchedule.map(item => `
+    return;
+  }
+
+  scheduleList.innerHTML = todayItems.map(item => {
+    if (item.type === 'exam-day') {
+      return `
+        <div class="schedule-item exam-day">
+          <div class="schedule-time">Today</div>
+          <div class="schedule-indicator exam-day" style="background:#111"></div>
+          <div class="schedule-content">
+            <div class="schedule-subject">
+              ${item.subject}
+              <span class="schedule-badge exam" style="background:#111;color:#fff;border-color:#111">EXAM DAY</span>
+            </div>
+            <div class="schedule-topic">${item.topic}</div>
+          </div>
+          <div class="schedule-duration">—</div>
+        </div>`;
+    }
+    return `
       <div class="schedule-item ${item.type}">
         <div class="schedule-time">${item.time}</div>
         <div class="schedule-indicator ${item.type}"></div>
         <div class="schedule-content">
           <div class="schedule-subject">
             ${item.subject}
-            ${item.type === 'exam' ? '<span class="schedule-badge exam">EXAM</span>' : ''}
-            ${item.type === 'scheduled' ? '<span class="schedule-badge scheduled">Scheduled</span>' : ''}
+            ${item.type === 'scheduled' ? '<span class="schedule-badge scheduled">Study</span>' : ''}
           </div>
           <div class="schedule-topic">${item.topic}</div>
         </div>
         <div class="schedule-duration">${item.duration}</div>
-      </div>`).join('');
-  }
+      </div>`;
+  }).join('');
 }
 
-function updateExams(exams) {
+// ── Upcoming exams ─────────────────────────────────────────────
+function updateExams(items) {
   const examsList = document.getElementById('examsList');
-  const today = new Date(); today.setHours(0, 0, 0, 0);
-  const upcoming = exams
-    .filter(e => new Date(e.examDate + 'T12:00:00') >= today)
-    .sort((a, b) => new Date(a.examDate) - new Date(b.examDate))
+  const today     = new Date(); today.setHours(0, 0, 0, 0);
+
+  const upcoming = items
+    .filter(i => i.type === 'exam' && new Date((i.dueDate || i.examDate) + 'T12:00:00') >= today)
+    .sort((a, b) => new Date(a.dueDate || a.examDate) - new Date(b.dueDate || b.examDate))
     .slice(0, 5);
 
   if (upcoming.length === 0) {
@@ -136,62 +264,94 @@ function updateExams(exams) {
         <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"></path></svg>
         <p>No upcoming exams</p>
       </div>`;
-  } else {
-    examsList.innerHTML = upcoming.map(exam => {
-      const daysLeft = Math.ceil((new Date(exam.examDate + 'T12:00:00') - today) / 86400000);
-      return `
-        <div class="exam-item">
-          <div class="exam-header">
-            <span class="exam-subject">${exam.subject}</span>
-            <span class="exam-badge">${daysLeft}d left</span>
-          </div>
-          <div class="exam-topic">${exam.topic}</div>
-          <div class="exam-date">${formatDateReadable(exam.examDate)}</div>
-        </div>`;
-    }).join('');
+    return;
   }
+
+  examsList.innerHTML = upcoming.map(exam => {
+    const dateStr  = exam.dueDate || exam.examDate;
+    const daysLeft = Math.ceil((new Date(dateStr + 'T12:00:00') - today) / 86400000);
+    return `
+      <div class="exam-item">
+        <div class="exam-header">
+          <span class="exam-subject">${exam.subject}</span>
+          <span class="exam-badge">${daysLeft}d left</span>
+        </div>
+        <div class="exam-topic">${exam.topic}</div>
+        <div class="exam-date">${formatDateReadable(dateStr)}</div>
+      </div>`;
+  }).join('');
 }
 
+// ── Weekly chart ───────────────────────────────────────────────
 function updateChart(sessions) {
-  const chart = document.getElementById('weeklyChart');
-  const weekStart = getWeekStart();
-  const weekData = [];
+  const chart       = document.getElementById('weeklyChart');
+  const weekStart   = getWeekStart();
+  const completions = DB.getCompletions(currentUser.id);
+  const weekData    = [];
+
   for (let i = 0; i < 7; i++) {
-    const day = new Date(weekStart);
+    const day    = new Date(weekStart);
     day.setDate(day.getDate() + i);
     const dayStr = day.toDateString();
-    const daySessions = sessions.filter(s => new Date(s.completedAt).toDateString() === dayStr);
-    const hours = daySessions.reduce((sum, s) => sum + s.duration / 60, 0);
-    weekData.push({ day: day.toLocaleDateString('en-US', { weekday: 'short' }), hours, isToday: dayStr === new Date().toDateString() });
+
+    // Timer session minutes + calendar block completion minutes
+    const sessionMins    = sessions.filter(s => new Date(s.completedAt).toDateString() === dayStr)
+                                   .reduce((sum, s) => sum + (s.duration || 0), 0);
+    const completionMins = completions.filter(c => new Date(c.completedAt).toDateString() === dayStr)
+                                      .reduce((sum, c) => sum + (c.durationMinutes || 0), 0);
+    const hours = (sessionMins + completionMins) / 60;
+
+    weekData.push({
+      day:     day.toLocaleDateString('en-US', { weekday: 'short' }),
+      hours,
+      isToday: dayStr === new Date().toDateString(),
+    });
   }
+
   const maxHours = Math.max(...weekData.map(d => d.hours), 4);
   chart.innerHTML = weekData.map(day => {
     const height = maxHours > 0 ? (day.hours / maxHours) * 100 : 0;
     return `
       <div class="chart-bar">
         <div class="chart-bar-inner">
-          <div class="chart-bar-fill ${day.isToday ? 'today' : ''}" style="height:${Math.max(height, day.hours > 0 ? 5 : 3)}%" title="${day.hours.toFixed(1)} hours"></div>
+          <div class="chart-bar-fill ${day.isToday ? 'today' : ''}"
+            style="height:${Math.max(height, day.hours > 0 ? 5 : 3)}%"
+            title="${day.hours.toFixed(1)} hours"></div>
         </div>
         <div class="chart-bar-label">${day.day}</div>
         ${day.isToday ? '<div class="chart-bar-indicator"></div>' : ''}
       </div>`;
   }).join('');
+
   const total = weekData.reduce((sum, d) => sum + d.hours, 0);
   document.getElementById('weeklyTotal').textContent = total.toFixed(1) + ' hours';
 }
 
+// ── Init ───────────────────────────────────────────────────────
 function init() {
-  const stats = DB.getStats(currentUser.id);
-  const exams = DB.getExams(currentUser.id);
+  const rawItems = DB.getItems ? DB.getItems(currentUser.id) : [];
+  const rawExams = DB.getExams(currentUser.id);
   const sessions = DB.getSessions(currentUser.id);
+
+  // Merge legacy exams into items list
+  const itemIds  = new Set(rawItems.map(i => i.id));
+  const allItems = [
+    ...rawItems,
+    ...rawExams
+      .filter(e => !itemIds.has(e.id))
+      .map(e => ({ ...e, type: 'exam', dueDate: e.examDate })),
+  ];
+
+  const stats = DB.getStats(currentUser.id);
   updateStats(stats, sessions);
-  updateSchedule(exams, sessions);
-  updateExams(exams);
+  updateSchedule(allItems, sessions);
+  updateExams(allItems);
   updateChart(sessions);
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('greeting').textContent = `${getTimeGreeting()}, ${currentUser.name}!`;
+  document.getElementById('greeting').textContent =
+    `${getTimeGreeting()}, ${currentUser.name}!`;
 
   document.getElementById('signOutBtn').addEventListener('click', () => {
     localStorage.removeItem('sf_current_user');

--- a/js/exams.js
+++ b/js/exams.js
@@ -12,7 +12,6 @@ let currentFilter      = 'all';
 const DIFF_HOURS  = { easy: 5, medium: 10, hard: 15, 'very-hard': 20 };
 const DIFF_LABELS = { easy: 'Easy', medium: 'Medium', hard: 'Hard', 'very-hard': 'Very Hard' };
 
-// SVG icons per type (inline, 14×14)
 const TYPE_ICONS = {
   exam:     `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/><line x1="8" x2="16" y1="7" y2="7"/><line x1="8" x2="14" y1="11" y2="11"/></svg>`,
   project:  `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>`,
@@ -26,21 +25,35 @@ function getDaysLeft(dateStr) {
   return Math.round((new Date(dateStr + 'T12:00:00') - today) / 86400000);
 }
 
-function getStudiedHours(item, sessions) {
+// Total studied hours for a subject:
+// combines timer sessions + calendar block completions for the same subject.
+function getStudiedHours(item, sessions, completions) {
   const sub = (item.subject || '').toLowerCase().trim();
-  return sessions
+
+  const sessionMins = sessions
     .filter(s => (s.subject || '').toLowerCase().trim() === sub)
-    .reduce((sum, s) => sum + (Number(s.duration) || 0) / 60, 0);
+    .reduce((sum, s) => sum + (Number(s.duration) || 0), 0);
+
+  const completionMins = (completions || [])
+    .filter(c => (c.subject || '').toLowerCase().trim() === sub)
+    .reduce((sum, c) => sum + (Number(c.durationMinutes) || 0), 0);
+
+  return (sessionMins + completionMins) / 60;
 }
 
-function getProgressPct(item, sessions) {
+function getProgressPct(item, sessions, completions) {
   if (item.type !== 'exam') return null;
   const req = DIFF_HOURS[item.difficulty] || 10;
-  return Math.min(100, Math.round((getStudiedHours(item, sessions) / req) * 100));
+  return Math.min(100, Math.round((getStudiedHours(item, sessions, completions) / req) * 100));
 }
 
 function getProgressColor(diff) {
-  return { easy:'var(--success)', medium:'var(--warning)', hard:'var(--destructive)', 'very-hard':'hsl(8,75%,48%)' }[diff] || 'var(--primary)';
+  return {
+    easy:        'var(--success)',
+    medium:      'var(--warning)',
+    hard:        'var(--destructive)',
+    'very-hard': 'hsl(8,75%,48%)',
+  }[diff] || 'var(--primary)';
 }
 
 // ── Toast ──────────────────────────────────────────────────────
@@ -54,7 +67,12 @@ function showToast(msg, type = 'success') {
     : '<circle cx="12" cy="12" r="10"/><line x1="15" x2="9" y1="9" y2="15"/><line x1="9" x2="15" y1="9" y2="15"/>';
   t.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">${icon}</svg>${msg}`;
   wrap.appendChild(t);
-  setTimeout(() => { t.style.transition='all .3s'; t.style.opacity='0'; t.style.transform='translateY(8px)'; setTimeout(() => t.remove(), 320); }, 3000);
+  setTimeout(() => {
+    t.style.transition = 'all .3s';
+    t.style.opacity    = '0';
+    t.style.transform  = 'translateY(8px)';
+    setTimeout(() => t.remove(), 320);
+  }, 3000);
 }
 
 // ── Type selector ──────────────────────────────────────────────
@@ -70,8 +88,8 @@ function selectType(btn) {
 
   const dateLabel = document.getElementById('dueDateLabel');
   if (dateLabel) dateLabel.textContent =
-    selectedType === 'exam'     ? 'Exam Date *'     :
-    selectedType === 'project'  ? 'Deadline *'      : 'Reminder Date *';
+    selectedType === 'exam'     ? 'Exam Date *'    :
+    selectedType === 'project'  ? 'Deadline *'     : 'Reminder Date *';
 }
 
 // ── Difficulty chip ────────────────────────────────────────────
@@ -144,11 +162,11 @@ function deleteExam(id, name) {
 }
 
 // ── Summary ───────────────────────────────────────────────────
-function updateSummary(items, sessions) {
+function updateSummary(items, sessions, completions) {
   const upcoming  = items.filter(i => getDaysLeft(i.dueDate || i.examDate) >= 0);
   const urgent    = upcoming.filter(i => getDaysLeft(i.dueDate || i.examDate) <= 7);
   const hoursLeft = upcoming.filter(i => i.type === 'exam').reduce((sum, e) => {
-    return sum + Math.max(0, (DIFF_HOURS[e.difficulty] || 10) - getStudiedHours(e, sessions));
+    return sum + Math.max(0, (DIFF_HOURS[e.difficulty] || 10) - getStudiedHours(e, sessions, completions));
   }, 0);
   const set = (id, v) => { const el = document.getElementById(id); if (el) el.textContent = v; };
   set('sumTotal',    items.length);
@@ -159,14 +177,15 @@ function updateSummary(items, sessions) {
 
 // ── Render cards ──────────────────────────────────────────────
 function renderItems() {
-  const items    = DB.getItems(currentUser.id);
-  const sessions = DB.getSessions(currentUser.id);
-  const grid     = document.getElementById('examsGrid');
+  const items       = DB.getItems(currentUser.id);
+  const sessions    = DB.getSessions(currentUser.id);
+  const completions = DB.getCompletions(currentUser.id);
+  const grid        = document.getElementById('examsGrid');
   if (!grid) return;
 
-  let filtered = [...items].sort((a, b) => {
-    return getDaysLeft(a.dueDate || a.examDate) - getDaysLeft(b.dueDate || b.examDate);
-  });
+  let filtered = [...items].sort((a, b) =>
+    getDaysLeft(a.dueDate || a.examDate) - getDaysLeft(b.dueDate || b.examDate)
+  );
 
   if (currentFilter === 'upcoming') filtered = filtered.filter(i => getDaysLeft(i.dueDate || i.examDate) >= 0);
   if (currentFilter === 'past')     filtered = filtered.filter(i => getDaysLeft(i.dueDate || i.examDate) <  0);
@@ -201,15 +220,15 @@ function renderItems() {
     const isSoon   = !isPast && !isUrgent && daysLeft <= 7;
 
     const daysClass = isPast ? 'past' : isUrgent ? 'urgent' : isSoon ? 'soon' : 'ok';
-    const daysText  = isPast  ? `${Math.abs(daysLeft)}d ago` : isToday ? 'Today!' : `${daysLeft}`;
-    const daysLabel = isPast  ? 'days ago' : isToday ? 'due today' : 'days left';
+    const daysText  = isPast   ? `${Math.abs(daysLeft)}d ago` : isToday ? 'Today!' : `${daysLeft}`;
+    const daysLabel = isPast   ? 'days ago' : isToday ? 'due today' : 'days left';
 
     const dateStr  = new Date(dateKey + 'T12:00:00').toLocaleDateString('en-US', { month:'short', day:'numeric', year:'numeric' });
     const safeName = item.subject.replace(/'/g, "\\'").replace(/"/g, '&quot;');
 
     const accentClass = item.type === 'exam' ? (item.difficulty || 'medium') : item.type;
-    const pct         = getProgressPct(item, sessions);
-    const studiedH    = item.type === 'exam' ? getStudiedHours(item, sessions) : 0;
+    const pct         = getProgressPct(item, sessions, completions);
+    const studiedH    = item.type === 'exam' ? getStudiedHours(item, sessions, completions) : 0;
     const requiredH   = DIFF_HOURS[item.difficulty] || 10;
     const typeIcon    = TYPE_ICONS[item.type] || TYPE_ICONS.exam;
     const typeLabel   = TYPE_LABELS[item.type] || 'Item';
@@ -265,9 +284,10 @@ function renderItems() {
 
 // ── Full re-render ────────────────────────────────────────────
 function renderAll() {
-  const items    = DB.getItems(currentUser.id);
-  const sessions = DB.getSessions(currentUser.id);
-  updateSummary(items, sessions);
+  const items       = DB.getItems(currentUser.id);
+  const sessions    = DB.getSessions(currentUser.id);
+  const completions = DB.getCompletions(currentUser.id);
+  updateSummary(items, sessions, completions);
   renderItems();
 }
 

--- a/js/settings.js
+++ b/js/settings.js
@@ -4,10 +4,8 @@ if (!currentUser) { window.location.replace('auth.html'); }
 
 else {
 
-// ── Pending confirm action ─────────────────────────────────────
 let pendingAction = null;
 
-// ── Safe DOM helper — never throws on missing elements ─────────
 function set(id, val) {
   const el = document.getElementById(id);
   if (el) el.textContent = val;
@@ -26,77 +24,195 @@ function showToast(msg, type = 'success') {
     fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"
     stroke-linejoin="round">${icon}</svg>${msg}`;
   wrap.appendChild(t);
-  setTimeout(() => {
-    t.style.transition = 'opacity .3s';
-    t.style.opacity = '0';
-    setTimeout(() => t.remove(), 320);
-  }, 3500);
+  setTimeout(() => { t.style.transition='opacity .3s'; t.style.opacity='0'; setTimeout(() => t.remove(), 320); }, 3500);
 }
 
 // ── Confirm dialog ─────────────────────────────────────────────
-function confirmClear() {
-  set('dialogTitle', 'Clear all study sessions?');
-  set('dialogSub', 'This will delete all session history and reset your streak and score. This cannot be undone.');
-  set('dialogConfirmBtn', 'Clear Data');
-  pendingAction = doClearSessions;
+function openDialog(title, sub, confirmLabel, action) {
+  set('dialogTitle', title);
+  set('dialogSub', sub);
+  set('dialogConfirmBtn', confirmLabel);
+  pendingAction = action;
   document.getElementById('confirmDialog')?.classList.add('show');
 }
-
-function confirmDeleteAccount() {
-  set('dialogTitle', 'Delete your account?');
-  set('dialogSub', 'This will permanently delete your account, all sessions, exams, and stats. This cannot be undone.');
-  set('dialogConfirmBtn', 'Delete Account');
-  pendingAction = doDeleteAccount;
-  document.getElementById('confirmDialog')?.classList.add('show');
-}
-
 function closeDialog() {
   document.getElementById('confirmDialog')?.classList.remove('show');
   pendingAction = null;
 }
-
-document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('dialogConfirmBtn')?.addEventListener('click', () => {
-    if (pendingAction) { pendingAction(); closeDialog(); }
-  });
-  document.getElementById('confirmDialog')?.addEventListener('click', (e) => {
-    if (e.target === document.getElementById('confirmDialog')) closeDialog();
-  });
-});
-
-// ── Clear sessions ─────────────────────────────────────────────
-function doClearSessions() {
-  const allSessions = DB._get(DB.SESSIONS_KEY);
-  DB._set(DB.SESSIONS_KEY, allSessions.filter(s => s.userId !== currentUser.id));
-  DB.updateStats(currentUser.id, { totalStudyHours: 0, streak: 0, lastStudyDate: null });
-  showToast('All sessions cleared', 'success');
-  init();
+function confirmClear() {
+  openDialog(
+    'Clear all study sessions?',
+    'This will delete all session history and reset your streak and score. This cannot be undone.',
+    'Clear Data',
+    doClearSessions
+  );
+}
+function confirmDeleteAccount() {
+  openDialog(
+    'Delete your account?',
+    'This will permanently delete your account, all sessions, exams, and stats. This cannot be undone.',
+    'Delete Account',
+    doDeleteAccount
+  );
 }
 
-// ── Delete account ─────────────────────────────────────────────
+// ── Danger actions ─────────────────────────────────────────────
+function doClearSessions() {
+  DB._set(DB.SESSIONS_KEY, DB._get(DB.SESSIONS_KEY).filter(s => s.userId !== currentUser.id));
+  DB._set(DB.COMPLETIONS_KEY, DB._get(DB.COMPLETIONS_KEY).filter(c => c.userId !== currentUser.id));
+  DB.updateStats(currentUser.id, { totalStudyHours: 0, streak: 0, lastStudyDate: null, studyScore: 0 });
+  showToast('All sessions cleared');
+  init();
+}
 function doDeleteAccount() {
-  const allSessions = DB._get(DB.SESSIONS_KEY);
-  DB._set(DB.SESSIONS_KEY, allSessions.filter(s => s.userId !== currentUser.id));
-  const allExams = DB._get(DB.EXAMS_KEY);
-  DB._set(DB.EXAMS_KEY, allExams.filter(e => e.userId !== currentUser.id));
-  const allStats = DB._get(DB.STATS_KEY);
-  DB._set(DB.STATS_KEY, allStats.filter(s => s.userId !== currentUser.id));
-  const allUsers = DB.getUsers();
-  DB._set(DB.USERS_KEY, allUsers.filter(u => u.id !== currentUser.id));
+  [DB.SESSIONS_KEY, DB.EXAMS_KEY, DB.ITEMS_KEY, DB.STATS_KEY, DB.COMPLETIONS_KEY].forEach(key => {
+    DB._set(key, DB._get(key).filter(r => r.userId !== currentUser.id));
+  });
+  DB._set(DB.USERS_KEY, DB.getUsers().filter(u => u.id !== currentUser.id));
   localStorage.removeItem('sf_current_user');
   window.location.href = 'index.html';
 }
-
-// ── Sign out ───────────────────────────────────────────────────
 function signOut() {
   localStorage.removeItem('sf_current_user');
   window.location.href = 'index.html';
 }
 
-// ── Main init — populate all data ──────────────────────────────
+// ── EXPORT ─────────────────────────────────────────────────────
+function exportData() {
+  const payload = {
+    exportedAt:  new Date().toISOString(),
+    exportedBy:  currentUser.email,
+    version:     2,
+    items:       DB.getItems(currentUser.id),
+    sessions:    DB.getSessions(currentUser.id),
+    completions: DB.getCompletions(currentUser.id),
+    stats:       DB.getStats(currentUser.id),
+  };
+
+  const json     = JSON.stringify(payload, null, 2);
+  const blob     = new Blob([json], { type: 'application/json' });
+  const url      = URL.createObjectURL(blob);
+  const a        = document.createElement('a');
+  const dateStr  = new Date().toISOString().split('T')[0];
+  a.href         = url;
+  a.download     = `studyflow-backup-${dateStr}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+  showToast('Data exported successfully');
+}
+
+// ── IMPORT ─────────────────────────────────────────────────────
+function triggerImport(mode) {
+  // mode: 'merge' | 'override'
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.json';
+  input.onchange = e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = ev => {
+      try {
+        const data = JSON.parse(ev.target.result);
+        if (!data.version || !Array.isArray(data.items)) {
+          showToast('Invalid backup file', 'error');
+          return;
+        }
+        if (mode === 'override') {
+          openDialog(
+            'Override your data?',
+            `This will replace all your current exams, projects, reminders, sessions and stats with the backup from ${data.exportedAt ? new Date(data.exportedAt).toLocaleDateString() : 'unknown date'}. This cannot be undone.`,
+            'Yes, Override',
+            () => doImport(data, 'override')
+          );
+        } else {
+          openDialog(
+            'Merge backup data?',
+            `This will add items from the backup that don't already exist in your account. Your current data won't be deleted. Backup from ${data.exportedAt ? new Date(data.exportedAt).toLocaleDateString() : 'unknown date'}.`,
+            'Yes, Merge',
+            () => doImport(data, 'merge')
+          );
+        }
+      } catch {
+        showToast('Could not read file \u2014 make sure it is a valid StudyFlow backup', 'error');
+      }
+    };
+    reader.readAsText(file);
+  };
+  input.click();
+}
+
+function doImport(data, mode) {
+  if (mode === 'override') {
+    // Wipe current user's data
+    DB._set(DB.ITEMS_KEY,       DB._get(DB.ITEMS_KEY).filter(i => i.userId !== currentUser.id));
+    DB._set(DB.SESSIONS_KEY,    DB._get(DB.SESSIONS_KEY).filter(s => s.userId !== currentUser.id));
+    DB._set(DB.COMPLETIONS_KEY, DB._get(DB.COMPLETIONS_KEY).filter(c => c.userId !== currentUser.id));
+
+    // Write backup data re-stamped with current userId
+    const items       = (data.items       || []).map(i => ({ ...i, userId: currentUser.id }));
+    const sessions    = (data.sessions    || []).map(s => ({ ...s, userId: currentUser.id }));
+    const completions = (data.completions || []).map(c => ({ ...c, userId: currentUser.id }));
+
+    DB._set(DB.ITEMS_KEY,       [...DB._get(DB.ITEMS_KEY),       ...items]);
+    DB._set(DB.SESSIONS_KEY,    [...DB._get(DB.SESSIONS_KEY),    ...sessions]);
+    DB._set(DB.COMPLETIONS_KEY, [...DB._get(DB.COMPLETIONS_KEY), ...completions]);
+
+    // Override stats (keep userId)
+    if (data.stats) {
+      DB.updateStats(currentUser.id, { ...data.stats, userId: currentUser.id });
+    }
+
+    const total = items.length + sessions.length;
+    showToast(`Override complete — ${total} records imported`);
+
+  } else {
+    // Merge: only add items whose id doesn't already exist
+    const existingItems    = new Set(DB.getItems(currentUser.id).map(i => i.id));
+    const existingSessions = new Set(DB.getSessions(currentUser.id).map(s => s.id));
+    const existingComps    = new Set(DB.getCompletions(currentUser.id).map(c => c.blockId));
+
+    const newItems       = (data.items       || []).filter(i => !existingItems.has(i.id))
+                            .map(i => ({ ...i, userId: currentUser.id }));
+    const newSessions    = (data.sessions    || []).filter(s => !existingSessions.has(s.id))
+                            .map(s => ({ ...s, userId: currentUser.id }));
+    const newCompletions = (data.completions || []).filter(c => !existingComps.has(c.blockId))
+                            .map(c => ({ ...c, userId: currentUser.id }));
+
+    DB._set(DB.ITEMS_KEY,       [...DB._get(DB.ITEMS_KEY),       ...newItems]);
+    DB._set(DB.SESSIONS_KEY,    [...DB._get(DB.SESSIONS_KEY),    ...newSessions]);
+    DB._set(DB.COMPLETIONS_KEY, [...DB._get(DB.COMPLETIONS_KEY), ...newCompletions]);
+
+    const added = newItems.length + newSessions.length;
+    const skipped = (data.items?.length || 0) + (data.sessions?.length || 0) - added;
+    showToast(`Merged — ${added} new records added${skipped > 0 ? `, ${skipped} duplicates skipped` : ''}`);
+  }
+
+  init();
+  updateExportPreview();
+}
+
+// ── Export preview ─────────────────────────────────────────────
+function updateExportPreview() {
+  const items       = DB.getItems(currentUser.id);
+  const sessions    = DB.getSessions(currentUser.id);
+  const completions = DB.getCompletions(currentUser.id);
+
+  set('previewExams',      items.filter(i => i.type === 'exam').length);
+  set('previewProjects',   items.filter(i => i.type === 'project').length);
+  set('previewReminders',  items.filter(i => i.type === 'reminder').length);
+  set('previewSessions',   sessions.length);
+  set('previewCompletions',completions.length);
+
+  // Rough file size estimate
+  const rough = JSON.stringify({ items, sessions, completions }).length;
+  const kb    = (rough / 1024).toFixed(1);
+  set('previewSize', kb + ' KB');
+}
+
+// ── Init ───────────────────────────────────────────────────────
 function init() {
   const name = (currentUser.name || '').trim() || 'Student';
-
   const avatar = document.getElementById('sAvatar');
   if (avatar) avatar.textContent = name.charAt(0).toUpperCase();
   set('sName',  name);
@@ -108,7 +224,7 @@ function init() {
   if (user?.createdAt) {
     set('rowMember', new Date(user.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' }));
   } else {
-    set('rowMember', 'Mar 2026');
+    set('rowMember', '—');
   }
 
   const stats    = DB.getStats(currentUser.id);
@@ -117,7 +233,7 @@ function init() {
 
   const totalHrs = parseFloat((stats.totalStudyHours || 0).toFixed(1));
   const streak   = stats.streak || 0;
-  const score    = Math.floor(totalHrs * 100);
+  const score    = stats.studyScore || 0;
 
   set('sTotalHrs', totalHrs + 'h');
   set('sStreak',   streak);
@@ -127,9 +243,18 @@ function init() {
   set('rowHours',    totalHrs + ' hrs');
   set('rowStreak',   streak + ' days');
   set('rowExams',    exams.length);
+
+  updateExportPreview();
 }
 
-// ── Boot ───────────────────────────────────────────────────────
-init();
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('dialogConfirmBtn')?.addEventListener('click', () => {
+    if (pendingAction) { pendingAction(); closeDialog(); }
+  });
+  document.getElementById('confirmDialog')?.addEventListener('click', e => {
+    if (e.target === document.getElementById('confirmDialog')) closeDialog();
+  });
+  init();
+});
 
 } // end else

--- a/settings.html
+++ b/settings.html
@@ -13,7 +13,7 @@
     .s-layout { display:grid; min-height:100vh; }
     @media(min-width:960px){ .s-layout { grid-template-columns:260px 1fr; } }
 
-    /* ── Left sidebar ───────────────────────────────────── */
+    /* ── Sidebar ───────────────────────────────────────────── */
     .s-sidebar { background:white; border-right:1px solid var(--border); padding:1.5rem 1rem; display:flex; flex-direction:column; gap:.2rem; min-height:100vh; }
     .s-logo { display:flex; align-items:center; gap:.6rem; text-decoration:none; color:var(--foreground); margin-bottom:1.5rem; padding:.25rem; }
     .s-logo-icon { width:2rem; height:2rem; border-radius:.5rem; background:var(--primary); display:flex; align-items:center; justify-content:center; color:#fff; }
@@ -23,7 +23,7 @@
     .s-nav-link.active { background:var(--primary); color:#fff; }
     .s-sidebar-bottom { margin-top:auto; padding-top:1rem; border-top:1px solid var(--border); }
 
-    /* ── Main content ───────────────────────────────────── */
+    /* ── Main ─────────────────────────────────────────────── */
     .s-main { padding:2rem; max-width:720px; }
     @media(max-width:960px){ .s-main { padding:1.25rem; } }
 
@@ -31,34 +31,19 @@
     .s-back { display:inline-flex; align-items:center; gap:.4rem; font-size:.82rem; color:var(--muted-foreground); text-decoration:none; padding:.5rem .875rem; border:1px solid var(--border); border-radius:.65rem; background:white; transition:all .2s; }
     .s-back:hover { background:var(--muted); color:var(--foreground); }
 
-    /* ── Page header ─────────────────────────────────────── */
     .s-header { margin-bottom:2rem; animation:fadeInUp .5s ease both; }
     .s-eyebrow { font-size:.7rem; font-weight:700; letter-spacing:.12em; text-transform:uppercase; color:var(--primary); margin-bottom:.5rem; }
     .s-title { font-size:2rem; font-weight:800; margin-bottom:.35rem; }
     .s-subtitle { font-size:.875rem; color:var(--muted-foreground); }
 
-    /* ── Sync notice banner ──────────────────────────────── */
-    .s-sync-banner {
-      display:flex; align-items:flex-start; gap:.875rem;
-      background:hsl(199,89%,97%); border:1px solid hsl(199,89%,82%);
-      border-radius:1rem; padding:1rem 1.25rem; margin-bottom:1.25rem;
-      animation:fadeInUp .5s ease .04s both;
-    }
-    .s-sync-icon {
-      width:2rem; height:2rem; border-radius:.5rem; flex-shrink:0;
-      background:hsl(199,89%,90%); color:hsl(199,89%,38%);
-      display:flex; align-items:center; justify-content:center; margin-top:.05rem;
-    }
+    /* ── Sync banner ──────────────────────────────────────── */
+    .s-sync-banner { display:flex; align-items:flex-start; gap:.875rem; background:hsl(199,89%,97%); border:1px solid hsl(199,89%,82%); border-radius:1rem; padding:1rem 1.25rem; margin-bottom:1.25rem; animation:fadeInUp .5s ease .04s both; }
+    .s-sync-icon { width:2rem; height:2rem; border-radius:.5rem; flex-shrink:0; background:hsl(199,89%,90%); color:hsl(199,89%,38%); display:flex; align-items:center; justify-content:center; margin-top:.05rem; }
     .s-sync-title { font-size:.82rem; font-weight:700; color:hsl(199,89%,28%); margin-bottom:.2rem; }
     .s-sync-sub { font-size:.77rem; color:hsl(199,60%,40%); line-height:1.55; }
-    .s-sync-badge {
-      margin-left:auto; flex-shrink:0; align-self:center;
-      font-size:.65rem; font-weight:700; letter-spacing:.06em; text-transform:uppercase;
-      padding:.2rem .55rem; border-radius:999px;
-      background:hsl(199,89%,88%); color:hsl(199,89%,28%);
-    }
+    .s-sync-badge { margin-left:auto; flex-shrink:0; align-self:center; font-size:.65rem; font-weight:700; letter-spacing:.06em; text-transform:uppercase; padding:.2rem .55rem; border-radius:999px; background:hsl(199,89%,88%); color:hsl(199,89%,28%); }
 
-    /* ── Profile card ─────────────────────────────────────── */
+    /* ── Profile ──────────────────────────────────────────── */
     .s-profile { background:white; border:1px solid var(--border); border-radius:1.25rem; padding:1.75rem; margin-bottom:1.25rem; display:flex; align-items:center; gap:1.5rem; animation:fadeInUp .5s ease .08s both; box-shadow:0 2px 12px rgba(0,0,0,.04); position:relative; overflow:hidden; }
     .s-profile::before { content:''; position:absolute; top:-40px; right:-40px; width:180px; height:180px; border-radius:50%; background:radial-gradient(circle,rgba(132,34,209,.06) 0%,transparent 70%); pointer-events:none; }
     .s-avatar { width:4.25rem; height:4.25rem; border-radius:1rem; background:linear-gradient(135deg,var(--primary),var(--primary-glow)); display:flex; align-items:center; justify-content:center; font-size:1.75rem; font-weight:800; color:#fff; flex-shrink:0; }
@@ -68,7 +53,7 @@
     .s-profile-badge { margin-top:.55rem; display:inline-flex; align-items:center; gap:.35rem; font-size:.72rem; font-weight:600; padding:.25rem .65rem; border-radius:999px; background:rgba(22,163,74,.1); color:var(--success); }
     .s-profile-badge::before { content:''; width:.45rem; height:.45rem; border-radius:50%; background:currentColor; }
 
-    /* ── Stats row ─────────────────────────────────────────── */
+    /* ── Stats row ────────────────────────────────────────── */
     .s-stats { display:grid; grid-template-columns:repeat(2,1fr); gap:.875rem; margin-bottom:1.25rem; animation:fadeInUp .5s ease .14s both; }
     @media(min-width:640px){ .s-stats { grid-template-columns:repeat(4,1fr); } }
     .s-stat { background:white; border:1px solid var(--border); border-radius:1rem; padding:1rem; box-shadow:0 1px 4px rgba(0,0,0,.04); transition:transform .2s, box-shadow .2s; }
@@ -77,104 +62,144 @@
     .s-stat-val { font-family:'DM Mono',monospace; font-size:1.4rem; font-weight:500; color:var(--foreground); margin-bottom:.15rem; }
     .s-stat-lbl { font-size:.7rem; color:var(--muted-foreground); font-weight:500; }
 
-    /* ── Sections ─────────────────────────────────────────── */
+    /* ── Section shell ────────────────────────────────────── */
     .s-section { background:white; border:1px solid var(--border); border-radius:1.25rem; margin-bottom:1rem; overflow:hidden; box-shadow:0 1px 6px rgba(0,0,0,.04); animation:fadeInUp .5s ease both; }
-    .s-section:nth-child(1){ animation-delay:.18s } .s-section:nth-child(2){ animation-delay:.22s } .s-section:nth-child(3){ animation-delay:.26s }
+    .s-section:nth-child(1){ animation-delay:.18s } .s-section:nth-child(2){ animation-delay:.22s } .s-section:nth-child(3){ animation-delay:.26s } .s-section:nth-child(4){ animation-delay:.30s }
     .s-section-header { padding:1.125rem 1.5rem; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:.75rem; }
     .s-section-icon { width:1.9rem; height:1.9rem; border-radius:.5rem; display:flex; align-items:center; justify-content:center; }
     .s-section-icon.purple { background:rgba(132,34,209,.08); color:var(--primary); }
-    .s-section-icon.blue { background:rgba(14,165,233,.08); color:hsl(199,89%,45%); }
-    .s-section-icon.red { background:rgba(239,68,68,.08); color:var(--destructive); }
+    .s-section-icon.blue   { background:rgba(14,165,233,.08);  color:hsl(199,89%,45%); }
+    .s-section-icon.green  { background:rgba(22,163,74,.08);   color:var(--success); }
+    .s-section-icon.red    { background:rgba(239,68,68,.08);   color:var(--destructive); }
     .s-section-title { font-size:.9rem; font-weight:700; }
     .s-section-sub { font-size:.74rem; color:var(--muted-foreground); margin-top:.1rem; }
-    .s-row { display:flex; align-items:center; justify-content:space-between; padding:1rem 1.5rem; border-bottom:1px solid hsl(40,20%,94%); transition:background .15s; }
+    .s-row { display:flex; align-items:center; justify-content:space-between; padding:1rem 1.5rem; border-bottom:1px solid hsl(40,20%,94%); transition:background .15s; gap:1rem; }
     .s-row:last-child { border-bottom:none; }
     .s-row:hover { background:hsl(40,20%,98%); }
-    .s-row-left { display:flex; align-items:center; gap:.75rem; }
+    .s-row-left { display:flex; align-items:center; gap:.75rem; flex:1; min-width:0; }
     .s-row-dot { width:.35rem; height:.35rem; border-radius:50%; background:hsl(40,20%,80%); flex-shrink:0; }
     .s-row-label { font-size:.875rem; font-weight:500; }
     .s-row-sub { font-size:.74rem; color:var(--muted-foreground); margin-top:.1rem; }
-    .s-row-val { font-size:.82rem; color:var(--muted-foreground); font-family:'DM Mono',monospace; }
+    .s-row-val { font-size:.82rem; color:var(--muted-foreground); font-family:'DM Mono',monospace; white-space:nowrap; }
 
-    /* ── Buttons ─────────────────────────────────────────── */
-    .s-btn { padding:.5rem 1rem; border-radius:.65rem; font-family:inherit; font-size:.8rem; font-weight:600; cursor:pointer; transition:all .2s; border:none; }
+    /* ── Buttons ──────────────────────────────────────────── */
+    .s-btn { display:inline-flex; align-items:center; gap:.4rem; padding:.5rem 1rem; border-radius:.65rem; font-family:inherit; font-size:.8rem; font-weight:600; cursor:pointer; transition:all .2s; border:none; white-space:nowrap; }
     .s-btn-danger { background:rgba(239,68,68,.08); color:var(--destructive); border:1px solid rgba(239,68,68,.2); }
     .s-btn-danger:hover { background:rgba(239,68,68,.15); }
     .s-btn-ghost { background:var(--muted); color:var(--foreground); border:1px solid var(--border); }
     .s-btn-ghost:hover { background:hsl(40,20%,88%); }
+    .s-btn-primary { background:var(--primary); color:white; border:1px solid transparent; }
+    .s-btn-primary:hover { background:hsl(270,74%,28%); }
+    .s-btn-outline { background:white; color:var(--foreground); border:1px solid var(--border); }
+    .s-btn-outline:hover { background:var(--muted); }
+
+    /* ── Transfer / export-import section ────────────────── */
+    .s-transfer-body { padding:1.25rem 1.5rem; }
+
+    /* preview pill grid */
+    .s-preview-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:.65rem; margin-bottom:1.25rem; }
+    @media(min-width:520px){ .s-preview-grid { grid-template-columns:repeat(6,1fr); } }
+    .s-pill { background:hsl(40,20%,97%); border:1px solid var(--border); border-radius:.75rem; padding:.6rem .75rem; text-align:center; }
+    .s-pill-val { font-family:'DM Mono',monospace; font-size:1.05rem; font-weight:600; color:var(--foreground); }
+    .s-pill-lbl { font-size:.62rem; font-weight:600; color:var(--muted-foreground); margin-top:.15rem; }
+
+    /* action cards */
+    .s-transfer-cards { display:grid; grid-template-columns:1fr 1fr; gap:.875rem; }
+    @media(max-width:480px){ .s-transfer-cards { grid-template-columns:1fr; } }
+
+    .s-transfer-card { border:1.5px solid var(--border); border-radius:1rem; padding:1.1rem 1.25rem; background:hsl(40,25%,98%); transition:border-color .2s, box-shadow .2s; }
+    .s-transfer-card:hover { border-color:hsl(40,20%,78%); box-shadow:0 3px 12px rgba(0,0,0,.06); }
+
+    .s-tc-head { display:flex; align-items:center; gap:.6rem; margin-bottom:.5rem; }
+    .s-tc-icon { width:2rem; height:2rem; border-radius:.5rem; display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+    .s-tc-icon.green  { background:rgba(22,163,74,.1);   color:var(--success); }
+    .s-tc-icon.blue   { background:rgba(59,130,246,.1);  color:hsl(221,83%,53%); }
+    .s-tc-icon.purple { background:rgba(132,34,209,.1);  color:var(--primary); }
+    .s-tc-title { font-size:.88rem; font-weight:700; }
+    .s-tc-desc { font-size:.75rem; color:var(--muted-foreground); line-height:1.5; margin-bottom:.85rem; }
+    .s-tc-btn-row { display:flex; gap:.5rem; flex-wrap:wrap; }
+
+    /* import mode note */
+    .s-import-note { display:flex; align-items:flex-start; gap:.6rem; background:hsl(45,80%,97%); border:1px solid hsl(45,80%,84%); border-radius:.75rem; padding:.75rem 1rem; margin-top:.875rem; font-size:.76rem; color:hsl(38,60%,35%); line-height:1.55; }
+    .s-import-note svg { flex-shrink:0; margin-top:.05rem; color:hsl(38,80%,45%); }
 
     /* ── Danger zone ──────────────────────────────────────── */
     .s-danger { border-color:rgba(239,68,68,.18); }
     .s-danger .s-section-header { border-bottom-color:rgba(239,68,68,.12); background:rgba(239,68,68,.02); }
     .s-danger .s-row-dot { background:rgba(239,68,68,.3); }
 
-    /* ── Confirm dialog ───────────────────────────────────── */
+    /* ── Dialog ───────────────────────────────────────────── */
     .s-dialog-overlay { position:fixed; inset:0; background:rgba(255,253,250,.8); backdrop-filter:blur(8px); display:flex; align-items:center; justify-content:center; z-index:100; opacity:0; pointer-events:none; transition:opacity .25s; }
     .s-dialog-overlay.show { opacity:1; pointer-events:all; }
-    .s-dialog { background:white; border:1px solid var(--border); border-radius:1.25rem; padding:2rem; max-width:380px; width:90%; box-shadow:0 24px 60px rgba(0,0,0,.12); transform:scale(.92); transition:transform .3s cubic-bezier(.34,1.56,.64,1); }
+    .s-dialog { background:white; border:1px solid var(--border); border-radius:1.25rem; padding:2rem; max-width:400px; width:90%; box-shadow:0 24px 60px rgba(0,0,0,.12); transform:scale(.92); transition:transform .3s cubic-bezier(.34,1.56,.64,1); }
     .s-dialog-overlay.show .s-dialog { transform:scale(1); }
-    .s-dialog-emoji { font-size:2.5rem; margin-bottom:.75rem; }
-    .s-dialog-title { font-size:1.15rem; font-weight:800; margin-bottom:.4rem; }
-    .s-dialog-sub { font-size:.875rem; color:var(--muted-foreground); margin-bottom:1.5rem; line-height:1.6; }
+    .s-dialog-icon { width:3rem; height:3rem; border-radius:.875rem; background:rgba(239,68,68,.08); display:flex; align-items:center; justify-content:center; color:var(--destructive); margin-bottom:.875rem; }
+    .s-dialog-title { font-size:1.1rem; font-weight:800; margin-bottom:.4rem; }
+    .s-dialog-sub { font-size:.84rem; color:var(--muted-foreground); margin-bottom:1.5rem; line-height:1.6; }
     .s-dialog-actions { display:flex; gap:.75rem; }
 
-    /* ── Toast ───────────────────────────────────────────── */
+    /* ── Toasts ───────────────────────────────────────────── */
     .s-toasts { position:fixed; bottom:1.5rem; right:1.5rem; display:flex; flex-direction:column; gap:.5rem; z-index:99; }
     .s-toast { display:flex; align-items:center; gap:.6rem; padding:.8rem 1.2rem; border-radius:.875rem; font-size:.8rem; background:var(--foreground); color:white; box-shadow:0 8px 24px rgba(0,0,0,.15); animation:toastIn .35s cubic-bezier(.34,1.56,.64,1) both; }
     .s-toast.success { background:hsl(158,50%,28%); }
-    .s-toast.error { background:hsl(8,60%,40%); }
-    @keyframes toastIn { from{transform:translateY(16px);opacity:0} to{transform:translateY(0);opacity:1} }
-    @keyframes fadeInUp { from{opacity:0;transform:translateY(16px)} to{opacity:1;transform:translateY(0)} }
+    .s-toast.error   { background:hsl(8,60%,40%); }
+
+    @keyframes toastIn   { from{transform:translateY(16px);opacity:0} to{transform:translateY(0);opacity:1} }
+    @keyframes fadeInUp  { from{opacity:0;transform:translateY(16px)} to{opacity:1;transform:translateY(0)} }
   </style>
 </head>
 <body>
 <div class="s-layout">
 
-  <!-- Sidebar (desktop only) -->
+  <!-- Sidebar -->
   <nav class="s-sidebar" id="sSidebar" style="display:none;">
-    <a href="index.html" class="logo">
-        <div class="logo-icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"></path>
-          </svg>
-        </div>
-        <span class="logo-text">StudyFlow</span>
-      </a>
-      <br>
+    <a href="index.html" class="s-logo">
+      <div class="s-logo-icon"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg></div>
+      <span class="s-logo-text">StudyFlow</span>
+    </a>
     <a href="dashboard.html" class="s-nav-link"><svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>Dashboard</a>
     <a href="calendar.html" class="s-nav-link"><svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="4" rx="2"/><line x1="16" x2="16" y1="2" y2="6"/><line x1="8" x2="8" y1="2" y2="6"/><line x1="3" x2="21" y1="10" y2="10"/></svg>Calendar</a>
     <a href="timer.html" class="s-nav-link"><svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="10" x2="14" y1="2" y2="2"/><line x1="12" x2="15" y1="14" y2="11"/><circle cx="12" cy="14" r="8"/></svg>Study Timer</a>
-    <a href="exams.html" class="s-nav-link"><svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"></path></svg>Exams</a>
+    <a href="exams.html" class="nav-item">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"></path></svg>
+      <span>Exams</span>
+    </a>
     <a href="achievements.html" class="s-nav-link">
-      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6"/><path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18"/><path d="M4 22h16"/><path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22"/><path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22"/><path d="M18 2H6v7a6 6 0 0 0 12 0V2z"/></svg>
-      <span>Achievements</span>
+      <svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6"/><path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18"/><path d="M4 22h16"/><path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22"/><path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22"/><path d="M18 2H6v7a6 6 0 0 0 12 0V2z"/></svg>
+      Achievements
     </a>
     <div class="s-sidebar-bottom">
-      <a href="settings.html" class="s-nav-link active"><svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>Settings</a>
+      <a href="settings.html" class="s-nav-link active">
+        <svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+        Settings
+      </a>
     </div>
   </nav>
 
   <!-- Main -->
   <main class="s-main">
     <div class="s-topbar">
-      <a href="dashboard.html" class="s-back"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>Dashboard</a>
+      <a href="dashboard.html" class="s-back">
+        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+        Dashboard
+      </a>
       <button class="s-btn s-btn-danger" onclick="signOut()">Sign Out</button>
     </div>
 
     <div class="s-header">
       <div class="s-eyebrow">Account</div>
       <h1 class="s-title">Settings</h1>
-      <p class="s-subtitle">Manage your profile, preferences, and data</p>
+      <p class="s-subtitle">Manage your profile, data transfer, and preferences</p>
     </div>
 
-    <!-- Sync notice banner -->
+    <!-- Sync banner -->
     <div class="s-sync-banner">
       <div class="s-sync-icon">
         <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/></svg>
       </div>
       <div>
         <div class="s-sync-title">Cross-device sync coming soon</div>
-        <div class="s-sync-sub">We're working on syncing your data across all your devices. For now, your sessions, exams, and progress are stored locally on this device only.</div>
+        <div class="s-sync-sub">Until then, use Export &amp; Import below to move your data between devices.</div>
       </div>
       <div class="s-sync-badge">In Progress</div>
     </div>
@@ -197,7 +222,7 @@
         <div class="s-stat-lbl">Study Hours</div>
       </div>
       <div class="s-stat">
-        <div class="s-stat-icon"><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"></path></svg></div>
+        <div class="s-stat-icon"><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"/></svg></div>
         <div class="s-stat-val" id="sStreak">0</div>
         <div class="s-stat-lbl">Day Streak</div>
       </div>
@@ -207,14 +232,91 @@
         <div class="s-stat-lbl">Study Score</div>
       </div>
       <div class="s-stat">
-        <div class="s-stat-icon"><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"></path></svg></div>
+        <div class="s-stat-icon"><svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg></div>
         <div class="s-stat-val" id="sExams">0</div>
         <div class="s-stat-lbl">Exams Added</div>
       </div>
     </div>
 
+    <!-- ── DATA TRANSFER ─────────────────────────────────── -->
+    <div class="s-section" style="animation-delay:.16s">
+      <div class="s-section-header">
+        <div class="s-section-icon green">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/></svg>
+        </div>
+        <div>
+          <div class="s-section-title">Data Transfer</div>
+          <div class="s-section-sub">Export your data to a file, or import from a backup to move between devices</div>
+        </div>
+      </div>
+
+      <div class="s-transfer-body">
+
+        <!-- Preview of what will be exported -->
+        <div style="font-size:.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted-foreground);margin-bottom:.65rem;">Your current data</div>
+        <div class="s-preview-grid">
+          <div class="s-pill"><div class="s-pill-val" id="previewExams">0</div><div class="s-pill-lbl">Exams</div></div>
+          <div class="s-pill"><div class="s-pill-val" id="previewProjects">0</div><div class="s-pill-lbl">Projects</div></div>
+          <div class="s-pill"><div class="s-pill-val" id="previewReminders">0</div><div class="s-pill-lbl">Reminders</div></div>
+          <div class="s-pill"><div class="s-pill-val" id="previewSessions">0</div><div class="s-pill-lbl">Sessions</div></div>
+          <div class="s-pill"><div class="s-pill-val" id="previewCompletions">0</div><div class="s-pill-lbl">Checked</div></div>
+          <div class="s-pill"><div class="s-pill-val" id="previewSize">0 KB</div><div class="s-pill-lbl">File size</div></div>
+        </div>
+
+        <!-- Action cards -->
+        <div class="s-transfer-cards">
+
+          <!-- Export -->
+          <div class="s-transfer-card">
+            <div class="s-tc-head">
+              <div class="s-tc-icon green">
+                <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+              </div>
+              <div class="s-tc-title">Export</div>
+            </div>
+            <div class="s-tc-desc">Download all your exams, projects, reminders, sessions and stats as a <code style="font-size:.72rem;background:var(--muted);padding:.1rem .3rem;border-radius:.3rem">.json</code> file.</div>
+            <div class="s-tc-btn-row">
+              <button class="s-btn s-btn-primary" onclick="exportData()">
+                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                Download Backup
+              </button>
+            </div>
+          </div>
+
+          <!-- Import -->
+          <div class="s-transfer-card">
+            <div class="s-tc-head">
+              <div class="s-tc-icon blue">
+                <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" x2="12" y1="3" y2="15"/></svg>
+              </div>
+              <div class="s-tc-title">Import</div>
+            </div>
+            <div class="s-tc-desc">Load a backup file from another device. Choose to <strong>merge</strong> (add new items only) or <strong>override</strong> (replace everything).</div>
+            <div class="s-tc-btn-row">
+              <button class="s-btn s-btn-outline" onclick="triggerImport('merge')">
+                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" x2="6" y1="9" y2="21"/></svg>
+                Merge
+              </button>
+              <button class="s-btn s-btn-danger" onclick="triggerImport('override')">
+                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/></svg>
+                Override
+              </button>
+            </div>
+          </div>
+
+        </div>
+
+        <!-- Info note -->
+        <div class="s-import-note">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/></svg>
+          <span><strong>Merge</strong> adds items from the backup that don't already exist — safe to use without losing anything. <strong>Override</strong> replaces all your current data with the backup — use this on a fresh device.</span>
+        </div>
+
+      </div>
+    </div>
+
     <!-- Account info -->
-    <div class="s-section">
+    <div class="s-section" style="animation-delay:.20s">
       <div class="s-section-header">
         <div class="s-section-icon purple"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></div>
         <div><div class="s-section-title">Account Info</div><div class="s-section-sub">Your profile details</div></div>
@@ -226,7 +328,7 @@
     </div>
 
     <!-- Study data -->
-    <div class="s-section">
+    <div class="s-section" style="animation-delay:.24s">
       <div class="s-section-header">
         <div class="s-section-icon blue"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg></div>
         <div><div class="s-section-title">Study Data</div><div class="s-section-sub">Your learning statistics</div></div>
@@ -238,7 +340,7 @@
     </div>
 
     <!-- Danger zone -->
-    <div class="s-section s-danger">
+    <div class="s-section s-danger" style="animation-delay:.28s">
       <div class="s-section-header">
         <div class="s-section-icon red"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" x2="12" y1="9" y2="13"/><line x1="12" x2="12.01" y1="17" y2="17"/></svg></div>
         <div><div class="s-section-title">Danger Zone</div><div class="s-section-sub">Irreversible actions — proceed with care</div></div>
@@ -256,18 +358,21 @@
         <button class="s-btn s-btn-danger" onclick="signOut()">Sign Out</button>
       </div>
     </div>
+
   </main>
 </div>
 
 <!-- Confirm dialog -->
 <div class="s-dialog-overlay" id="confirmDialog">
   <div class="s-dialog">
-    <div class="s-dialog-emoji">⚠️</div>
+    <div class="s-dialog-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" x2="12" y1="9" y2="13"/><line x1="12" x2="12.01" y1="17" y2="17"/></svg>
+    </div>
     <div class="s-dialog-title" id="dialogTitle">Are you sure?</div>
-    <div class="s-dialog-sub" id="dialogSub">This action cannot be undone.</div>
+    <div class="s-dialog-sub"   id="dialogSub">This action cannot be undone.</div>
     <div class="s-dialog-actions">
-      <button class="s-btn s-btn-ghost" onclick="closeDialog()" style="flex:1;">Cancel</button>
-      <button class="s-btn s-btn-danger" id="dialogConfirmBtn" style="flex:1;">Confirm</button>
+      <button class="s-btn s-btn-ghost"  onclick="closeDialog()" style="flex:1">Cancel</button>
+      <button class="s-btn s-btn-danger" id="dialogConfirmBtn"   style="flex:1">Confirm</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION

### What was added
 
**Unified Planner (`exams.html` / `exams.js`)**
- Replaced the exams-only form with a type selector — Exam, Project, Reminder
- Exams keep difficulty + auto-generated study schedule
- Projects appear as deadline events on the calendar
- Reminders fire a notify block N days before the due date (configurable)
- Optional notes field on all item types
- Filter tabs: All / Upcoming / Exams / Projects / Reminders / Past
- SVG icons throughout, no emojis
- Progress bar on each exam card now counts both timer sessions **and** calendar block completions
- "Prep Hours Left" summary stat is accurate across both sources
 
**DB layer (`db.js`)**
- New `sf_items` store for unified exam/project/reminder data
- Legacy `sf_exams` proxied through `getItems` for backwards compatibility
- `completeBlock` / `uncompleteBlock` — updates stats directly, never writes to `sf_sessions` (fixes calendar item cloning bug)
- `studyScore` tracked as a separate field on stats
- `sf_completions` store for calendar block state
 
**Calendar — Scheduling Logic (`calendar.js`)**
- Study sessions are now **consecutive with no gaps**: the scheduler works backwards from the exam date, calculates exactly how many days are needed at the 2h/day cap, and starts on precisely that day — no idle days, no early start
- Exam day always shows a dedicated marker (black cell + banner); no study session scheduled on exam day itself
- Removed `STUDY_START_DAYS_BEFORE` — scheduling is now driven entirely by hours needed, not arbitrary lead times
 
**Calendar — Completions & Stats (`calendar.js` / `dashboard.js`)**
- Scheduled study blocks have a Mark done button; checking earns +1.5 pts/min Study Score, updates streak and total hours
- Unchecking fully reverses stats
- Floating `+N pts` score toast on completion
- Day cells show a `done/total` completion counter
- Dashboard "Studied Today", "Weekly Goal", weekly chart bars, and "Prep Hours Left" all now combine timer sessions + calendar block completions
 
**Calendar — Visual Upgrades (`calendar.html` / `calendar.js`)**
- **Week progress bar** — gradient bar showing % of this week's sessions completed, live-updating on check/uncheck
- **Week summary strip** — sessions done, total sessions, study hours, exam count for the current week
- **Jump to Today button** — snaps back to current week and selects today
- **Per-day completion rings** — small SVG ring in each week grid cell, fills as sessions are completed, turns green at 100%
- **Day completion ring** — larger ring in the day detail header showing % complete for the selected day
- **Colored left border on session cards** — each card gets a border in its difficulty color (green/yellow/red/purple)
- **Difficulty dot** — small colored circle before subject name on each study card
- **Project cards** — blue tinted card with left accent stripe, icon circle, "DUE" badge
- **Reminder cards** — amber card with amber stripe, icon circle, "TODAY" badge
- **Notify cards** — soft purple card with purple stripe, icon circle, "SOON" badge
- All event cards have hover lift animation
- Score tag has star/checkmark SVG icons instead of plain text
 
**Achievements (`achievements.html` / `achievements.js`)**
- 25 unlockable achievements across 6 categories: Streak, Hours, Sessions, Planner, Score, Special
- Each card shows icon, title, description, live progress bar, and a green check when earned
- Animated SVG completion ring showing overall unlock percentage
- Activity heatmap (15 weeks, GitHub-style, purple intensity)
- Weekly hours bar chart (last 8 weeks)
- Top subjects breakdown bar chart
- Planner stats: exams, projects, reminders, calendar blocks checked
- Filter by category
 
**Data Transfer (`settings.html` / `settings.js`)**
- Export — downloads a `studyflow-backup-YYYY-MM-DD.json` with all items, sessions, completions and stats
- Import Merge — adds records from backup that don't already exist (deduped by id), safe to run multiple times
- Import Override — wipes current data and replaces with backup, for moving to a new device
- Live preview grid showing record counts and estimated file size before export
- Confirmation dialog before any destructive import
 
---
 
### Bug fixes
 
- **Calendar week progress bar** — was using `>=`/`<=` on Date objects (broken by time components); fixed to ISO date string comparison
- **Day completion ring wrong count** — was counting exam-day markers as "completed"; now only counts `scheduled` and `session` types
- **Small day-cell rings** — circumference mismatch (`r=9` ring used wrong constant); fixed to `CIRC_SMALL = 2π×9`
- **Large day ring** — `dcrFill`/`dcrText` variables accidentally dropped in a refactor; re-added with correct `stroke-dasharray` set dynamically
- **Exams progress bar stuck at 0%** — `getStudiedHours` only read timer sessions, ignoring `sf_completions`; now sums both sources
- **Dashboard stats ignoring calendar blocks** — "Studied Today", "Weekly Goal %", weekly chart all now include `sf_completions` minutes
- **Study Score display** — was computed as `totalStudyHours * 100` (wrong); now reads `stats.studyScore` directly
 
---
 
### Files changed
 
| File | Change |
|---|---|
| `js/calendar.js` | Scheduler rewrite, consecutive sessions, exam-day marker, completion rings, progress bar, event card rendering |
| `calendar.html` | Week progress bar, summary strip, jump-to-today button, event card CSS, ring CSS |
| `js/dashboard.js` | Schedule generator mirrored from calendar.js, stats now include completions |
| `js/exams.js` | Progress bar fix — completions passed to `getStudiedHours` |
| `js/db.js` | `sf_items`, `sf_completions`, `completeBlock`, `uncompleteBlock`, `studyScore` |
| `exams.html` | Unified planner UI — type selector, filter tabs, project/reminder support |
| `achievements.html` / `js/achievements.js` | New page — 25 achievements, heatmap, charts |
| `settings.html` / `js/settings.js` | Export / import merge / import override |